### PR TITLE
Add animated metaball preloader and loading shell

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { ReactNode } from "react";
 import ThemeScript from "./theme/ThemeScript";
+import AppShell from "@/components/AppShell";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -9,7 +10,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ThemeScript />
       </head>
       <body className="bg-bg text-fg antialiased selection:bg-white/20 dark:selection:bg-white/10">
-        {children}
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ReactNode, useCallback, useState } from "react";
+import Preloader from "./Preloader";
+
+interface AppShellProps {
+  children: ReactNode;
+}
+
+export default function AppShell({ children }: AppShellProps) {
+  const [isReady, setIsReady] = useState(false);
+
+  const handleComplete = useCallback(() => {
+    setIsReady(true);
+  }, []);
+
+  return (
+    <>
+      {!isReady && <Preloader onComplete={handleComplete} />}
+      <div
+        className={`transition-opacity duration-700 ${
+          isReady ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        aria-hidden={!isReady}
+        aria-busy={!isReady}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Canvas } from '@react-three/fiber';
-import { Suspense, useEffect } from 'react';
-import { Environment, OrbitControls, Html } from '@react-three/drei';
-import Preloader from './Preloader';
-import Shapes from './shapes/ProceduralShapes';
-import { useVariantStore } from '../store/variants';
+import { Canvas } from "@react-three/fiber";
+import { Suspense, useEffect } from "react";
+import { Html } from "@react-three/drei";
+import Shapes from "./shapes/ProceduralShapes";
+import { useVariantStore } from "../store/variants";
 
 interface ExperienceProps {
   /**
@@ -14,7 +13,7 @@ interface ExperienceProps {
    * repositions the shapes to spell out a different arrangement or
    * create a different composition.  See `store/variants.ts`.
    */
-  variant: 'home' | 'about' | 'work' | 'contact';
+  variant: "home" | "about" | "work" | "contact";
 }
 
 export default function Experience({ variant }: ExperienceProps) {
@@ -28,7 +27,7 @@ export default function Experience({ variant }: ExperienceProps) {
   }, [variant, setVariant]);
 
   return (
-    <div className="w-screen h-screen">
+    <div className="h-screen w-screen">
       <Canvas
         camera={{ position: [0, 0, 6], fov: 40 }}
         gl={{ antialias: true, alpha: false }}
@@ -37,20 +36,22 @@ export default function Experience({ variant }: ExperienceProps) {
         {/* Ambient and directional lighting to softly illuminate the shapes */}
         <ambientLight intensity={0.5} />
         <directionalLight position={[5, 5, 5]} intensity={1.2} />
-        {/* Optionally enable OrbitControls during development.  Uncomment to
-            orbit the camera around the scene. */}
+        {/* Optionally enable OrbitControls during development.  Uncomment to */}
+        {/* orbit the camera around the scene. */}
         {/* <OrbitControls enableDamping /> */}
         <Suspense
           fallback={
             <Html center>
-              <Preloader />
+              <div className="rounded-full bg-fg/10 px-6 py-3 text-sm font-medium text-fg/70 shadow-soft">
+                Materializing shapes…
+              </div>
             </Html>
           }
         >
           <Shapes />
-          {/* Optional environment map; remove if not used.  You can place
-              an HDRI in public and reference it here to get realistic
-              reflections. */}
+          {/* Optional environment map; remove if not used.  You can place */}
+          {/* an HDRI in public and reference it here to get realistic */}
+          {/* reflections. */}
           {/* <Environment preset="city" /> */}
         </Suspense>
       </Canvas>

--- a/components/three/Metaballs.tsx
+++ b/components/three/Metaballs.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { MarchingCubes, MarchingPlane } from "@react-three/drei";
+import { useMemo, useRef } from "react";
+import { Color } from "three";
+import type { MarchingCubes as MarchingCubesImpl } from "three/examples/jsm/objects/MarchingCubes";
+
+type Metaball = {
+  color: Color;
+  offset: number;
+  radius: number;
+  speed: number;
+};
+
+const pastelPalette = ["#fbcfe8", "#fde68a", "#bfdbfe", "#e9d5ff", "#c8f7dc"];
+
+export default function Metaballs() {
+  const marchingRef = useRef<MarchingCubesImpl | null>(null);
+  const metaballs = useMemo<Metaball[]>(
+    () =>
+      pastelPalette.map((hex, index) => ({
+        color: new Color(hex),
+        offset: (index / pastelPalette.length) * Math.PI * 2,
+        radius: 0.38 + index * 0.03,
+        speed: 0.6 + index * 0.15,
+      })),
+    [],
+  );
+
+  useFrame(({ clock }) => {
+    const marching = marchingRef.current;
+    if (!marching) return;
+
+    marching.reset();
+    const time = clock.getElapsedTime();
+
+    metaballs.forEach((ball, index) => {
+      const phase = time * ball.speed + ball.offset;
+      const x = Math.sin(phase * 0.9 + index * 0.3) * 0.55;
+      const y = Math.cos(phase * 1.1 + index * 0.45) * 0.55;
+      const z = Math.sin(phase * 0.7 + index * 0.6) * 0.55;
+
+      marching.addBall(x, y, z, ball.radius, 5, ball.color);
+    });
+
+    marching.update();
+  });
+
+  return (
+    <MarchingCubes
+      ref={marchingRef}
+      resolution={32}
+      maxPolyCount={12000}
+      enableColors
+      isovalue={0.15}
+    >
+      <MarchingPlane planeType="z" constant={-1} />
+      <meshStandardMaterial vertexColors roughness={0.35} metalness={0.15} />
+    </MarchingCubes>
+  );
+}

--- a/components/three/MetaballsCanvas.tsx
+++ b/components/three/MetaballsCanvas.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Canvas } from "@react-three/fiber";
+import { Environment, Float } from "@react-three/drei";
+import Metaballs from "./Metaballs";
+
+export default function MetaballsCanvas() {
+  return (
+    <Canvas
+      className="h-48 w-48"
+      camera={{ position: [0, 0, 4.5], fov: 45 }}
+      gl={{ antialias: true, alpha: true }}
+      dpr={[1, 1.5]}
+    >
+      <color attach="background" args={["#fef9ff"]} />
+      <ambientLight intensity={0.7} />
+      <directionalLight position={[3, 4, 5]} intensity={1.1} />
+      <Float
+        rotationIntensity={0.25}
+        floatIntensity={0.6}
+        speed={1}
+        floatingRange={[-0.1, 0.1]}
+      >
+        <Metaballs />
+      </Float>
+      <Environment preset="studio" />
+    </Canvas>
+  );
+}


### PR DESCRIPTION
## Summary
- create an animated MarchingCubes metaballs scene for the loading experience
- render a client-only Canvas preloader with Suspense, progress text, and pastel visuals
- wrap the application with a loading shell that hides content until the preloader finishes

## Testing
- npm run build *(fails: existing type error in components/shapes/ProceduralShapes.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d9653e18b0832fa1936ac0c08c0a41