### PR TITLE
Refine animated menu overlay and fix build issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,18 +30,18 @@ html, body {
 }
 
 .btn {
-  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-[transform,box-shadow,background-color,color] duration-300 ease-pleasant;
-  @apply shadow-soft hover:scale-[1.02] active:scale-[0.98];
-  background: linear-gradient(180deg, theme('colors.brand.400'), theme('colors.brand.600'));
+  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-[transform,box-shadow,background-color,color] duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
+  @apply shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] hover:scale-[1.02] active:scale-[0.98];
+  background: linear-gradient(180deg, #7ab6ff, #2a63e6);
   color: white;
 }
 .btn-secondary {
-  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition duration-300 ease-pleasant;
+  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
   background: rgb(var(--fg) / 0.07);
   color: rgb(var(--fg));
 }
 .link {
-  @apply underline underline-offset-4 decoration-transparent hover:decoration-current transition-colors duration-300 ease-pleasant;
+  @apply underline underline-offset-4 decoration-transparent hover:decoration-current transition-colors duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
 }
 
 /* 4) Acessibilidade: reduz animações */

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -42,7 +42,7 @@ export default function Experience({ variant }: ExperienceProps) {
         <Suspense
           fallback={
             <Html center>
-              <div className="rounded-full bg-fg/10 px-6 py-3 text-sm font-medium text-fg/70 shadow-soft">
+              <div className="rounded-full bg-fg/10 px-6 py-3 text-sm font-medium text-fg/70 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)]">
                 Materializing shapes…
               </div>
             </Html>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,38 +1,230 @@
 "use client";
 
-import Link from 'next/link';
-import { useVariantStore } from '../store/variants';
+import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import dynamic from "next/dynamic";
+import { Suspense, useEffect, useRef, useState } from "react";
 
-/**
- * A simple navigation bar that links to the four sections of the site.
- * Clicking a link triggers a route change handled by the Next.js App
- * Router.  Because each page sets the variant on mount, the shapes
- * animate to their new positions accordingly.  The current page is
- * highlighted with an underline.
- */
+const MetaballsCanvas = dynamic(() => import("./three/MetaballsCanvas"), {
+  ssr: false,
+  loading: () => <div className="h-48 w-48 animate-pulse rounded-full bg-fg/10" />,
+});
+
+const navigationLinks = [
+  { name: "home", href: "/" },
+  { name: "work", href: "/work" },
+  { name: "about", href: "/about" },
+  { name: "contact", href: "/contact" },
+] as const;
+
+const socialLinks = [
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/duartois" },
+  { label: "Behance", href: "https://www.behance.net/duartois" },
+  { label: "Dribbble", href: "https://dribbble.com/duartois" },
+  { label: "Instagram", href: "https://www.instagram.com/duartois" },
+] as const;
+
 export default function Navbar() {
-  const current = useVariantStore((state) => state.variantName);
-  const items: { name: string; href: string; key: typeof current }[] = [
-    { name: 'home', href: '/', key: 'home' },
-    { name: 'about', href: '/about', key: 'about' },
-    { name: 'work', href: '/work', key: 'work' },
-    { name: 'contact', href: '/contact', key: 'contact' },
-  ];
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+  const firstLinkRef = useRef<HTMLAnchorElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const hasOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      firstLinkRef.current?.focus();
+      document.body.classList.add("overflow-hidden");
+      hasOpenedRef.current = true;
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          setIsOpen(false);
+        }
+      };
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+        document.body.classList.remove("overflow-hidden");
+      };
+    }
+
+    document.body.classList.remove("overflow-hidden");
+    if (hasOpenedRef.current) {
+      triggerRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, []);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
   return (
-    <nav className="absolute top-4 left-1/2 z-10 -translate-x-1/2 flex gap-6 text-sm uppercase tracking-wider select-none">
-      {items.map(({ name, href, key }) => (
-        <Link
-          key={key}
-          href={href}
-          className={
-            current === key
-              ? 'text-white underline underline-offset-4'
-              : 'text-gray-400 hover:text-white transition-colors'
-          }
-        >
-          {name}
-        </Link>
-      ))}
-    </nav>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls="main-navigation-overlay"
+        className="group fixed right-6 top-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-fg/20 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition hover:border-fg/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+      >
+        <span className="sr-only">{isOpen ? "Fechar navegação" : "Abrir navegação"}</span>
+        <span aria-hidden="true" className="grid grid-cols-3 gap-1.5">
+          {Array.from({ length: 9 }).map((_, index) => (
+            <motion.span
+              key={index}
+              layout
+              className="h-1.5 w-1.5 rounded-full bg-fg transition group-hover:scale-110 group-focus-visible:scale-110"
+              animate={
+                isOpen
+                  ? {
+                      scale: 0.6,
+                      opacity: 0.35,
+                    }
+                  : {
+                      scale: 1,
+                      opacity: 1,
+                    }
+              }
+              transition={{ duration: 0.3, ease: "easeInOut" }}
+            />
+          ))}
+        </span>
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            id="main-navigation-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="main-navigation-title"
+            tabIndex={-1}
+            className="fixed inset-0 z-40 overflow-hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25, ease: "easeInOut" }}
+          >
+            <motion.div
+              className="absolute inset-0 bg-gradient-to-br from-[#05060f] via-[#070b1f]/95 to-[#010106]"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.35, ease: "easeInOut" }}
+            />
+            <div className="pointer-events-none absolute inset-0 opacity-50">
+              <Suspense fallback={null}>
+                <div className="absolute left-1/2 top-1/2 h-[min(70vh,36rem)] w-[min(70vh,36rem)] -translate-x-1/2 -translate-y-1/2">
+                  <MetaballsCanvas />
+                </div>
+              </Suspense>
+            </div>
+
+            <motion.div
+              className="relative z-10 flex h-full w-full flex-col"
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 24 }}
+              transition={{ duration: 0.35, ease: "easeOut" }}
+            >
+              <header className="flex items-center justify-between px-6 pt-10 text-xs uppercase tracking-[0.4em] text-fg/60 md:px-12">
+                <motion.span
+                  id="main-navigation-title"
+                  initial={{ y: -8, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  transition={{ delay: 0.1, duration: 0.3 }}
+                >
+                  Menu
+                </motion.span>
+                <motion.button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="flex items-center gap-2 rounded-full bg-fg/10 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-fg transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                  initial={{ y: -8, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  transition={{ delay: 0.15, duration: 0.3 }}
+                >
+                  Close
+                </motion.button>
+              </header>
+
+              <div className="flex flex-1 flex-col justify-end gap-16 px-6 pb-12 text-left md:flex-row md:items-end md:justify-between md:px-12 md:pb-16">
+                <nav aria-label="Primary" className="w-full md:w-auto">
+                  <motion.ul
+                    className="flex flex-col gap-6 text-4xl font-semibold uppercase tracking-[0.3em] text-fg sm:text-5xl md:text-[clamp(3rem,6vw,4.5rem)]"
+                    initial="hidden"
+                    animate="visible"
+                    variants={{
+                      hidden: {},
+                      visible: {
+                        transition: { staggerChildren: 0.08, delayChildren: 0.15 },
+                      },
+                    }}
+                  >
+                    {navigationLinks.map(({ name, href }, index) => (
+                      <motion.li
+                        key={href}
+                        variants={{
+                          hidden: { opacity: 0, y: 24 },
+                          visible: { opacity: 1, y: 0 },
+                        }}
+                      >
+                        <Link
+                          ref={index === 0 ? firstLinkRef : undefined}
+                          href={href}
+                          onClick={() => setIsOpen(false)}
+                          className="group flex items-center gap-6 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
+                        >
+                          <span className="text-sm font-normal tracking-[0.4em] text-fg/40">0{index + 1}</span>
+                          <span className="relative">
+                            <span className="block transition duration-300 ease-out group-hover:-translate-y-1">{name}</span>
+                            <span className="absolute inset-x-0 bottom-0 h-[3px] origin-left scale-x-0 bg-fg/80 transition-transform duration-300 ease-out group-hover:scale-x-100" />
+                          </span>
+                        </Link>
+                      </motion.li>
+                    ))}
+                  </motion.ul>
+                </nav>
+
+                <motion.div
+                  className="flex w-full flex-col gap-8 text-sm uppercase tracking-[0.35em] text-fg/60 md:w-64"
+                  initial={{ opacity: 0, y: 24 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.35, duration: 0.4 }}
+                >
+                  <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
+                    <span>Social</span>
+                    <div className="h-px w-16 bg-fg/20" />
+                  </div>
+                  <div className="flex flex-wrap gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.35em]">
+                    {socialLinks.map(({ label, href }) => (
+                      <Link
+                        key={label}
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        prefetch={false}
+                        className="rounded-full bg-fg/10 px-5 py-2 transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                      >
+                        {label}
+                      </Link>
+                    ))}
+                  </div>
+                </motion.div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/components/shapes/ProceduralShapes.tsx
+++ b/components/shapes/ProceduralShapes.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo } from 'react';
 import { CatmullRomCurve3, TorusGeometry, TubeGeometry, SphereGeometry, Vector3 } from 'three';
-import { useSpring, animated } from '@react-spring/three';
+import type { Vector3Tuple } from 'three';
+import { a, useSpring } from '@react-spring/three';
 import { useVariantStore } from '../../store/variants';
 import GradientMat from '../../materials/GradientMat';
 
@@ -37,61 +38,80 @@ export default function ProceduralShapes() {
 
   // Animations: each shape uses its own spring to interpolate towards
   // the target position and rotation defined in the variant store.
+  const tuple = (value: [number, number, number]) => value as Vector3Tuple;
+  const sharedConfig = { mass: 5, tension: 300, friction: 50 } as const;
+
   const cTopSpring = useSpring({
-    position: variant.cTop.position,
-    rotation: variant.cTop.rotation,
-    config: { mass: 5, tension: 300, friction: 50 },
+    position: tuple(variant.cTop.position),
+    rotationX: variant.cTop.rotation[0],
+    rotationY: variant.cTop.rotation[1],
+    rotationZ: variant.cTop.rotation[2],
+    config: sharedConfig,
   });
   const cBottomSpring = useSpring({
-    position: variant.cBottom.position,
-    rotation: variant.cBottom.rotation,
-    config: { mass: 5, tension: 300, friction: 50 },
+    position: tuple(variant.cBottom.position),
+    rotationX: variant.cBottom.rotation[0],
+    rotationY: variant.cBottom.rotation[1],
+    rotationZ: variant.cBottom.rotation[2],
+    config: sharedConfig,
   });
   const sSpring = useSpring({
-    position: variant.sShape.position,
-    rotation: variant.sShape.rotation,
-    config: { mass: 5, tension: 300, friction: 50 },
+    position: tuple(variant.sShape.position),
+    rotationX: variant.sShape.rotation[0],
+    rotationY: variant.sShape.rotation[1],
+    rotationZ: variant.sShape.rotation[2],
+    config: sharedConfig,
   });
   const dotSpring = useSpring({
-    position: variant.dot.position,
-    rotation: variant.dot.rotation,
-    config: { mass: 5, tension: 300, friction: 50 },
+    position: tuple(variant.dot.position),
+    rotationX: variant.dot.rotation[0],
+    rotationY: variant.dot.rotation[1],
+    rotationZ: variant.dot.rotation[2],
+    config: sharedConfig,
   });
 
   return (
     <>
       {/* Top C shape */}
-      <animated.mesh
+      <a.mesh
         geometry={cGeometry}
         position={cTopSpring.position}
-        rotation={cTopSpring.rotation}
+        rotation-x={cTopSpring.rotationX}
+        rotation-y={cTopSpring.rotationY}
+        rotation-z={cTopSpring.rotationZ}
       >
         <GradientMat colorA="#9CA3AF" colorB="#6366F1" fresnelStrength={1.2} />
-      </animated.mesh>
+      </a.mesh>
       {/* Bottom C shape */}
-      <animated.mesh
+      <a.mesh
         geometry={cBottomGeometry}
         position={cBottomSpring.position}
-        rotation={cBottomSpring.rotation}
+        rotation-x={cBottomSpring.rotationX}
+        rotation-y={cBottomSpring.rotationY}
+        rotation-z={cBottomSpring.rotationZ}
       >
         <GradientMat colorA="#60A5FA" colorB="#4338CA" fresnelStrength={1.2} />
-      </animated.mesh>
+      </a.mesh>
       {/* S shape built from a tube along a Catmull Rom curve */}
-      <animated.mesh
+      <a.mesh
         geometry={sGeometry}
         position={sSpring.position}
-        rotation={sSpring.rotation}
+        rotation-x={sSpring.rotationX}
+        rotation-y={sSpring.rotationY}
+        rotation-z={sSpring.rotationZ}
       >
         <GradientMat colorA="#F472B6" colorB="#EC4899" fresnelStrength={1.2} />
-      </animated.mesh>
+      </a.mesh>
       {/* Dot */}
-      <animated.mesh
+      <a.mesh
         geometry={dotGeometry}
         position={dotSpring.position}
-        rotation={dotSpring.rotation}
+        rotation-x={dotSpring.rotationX}
+        rotation-y={dotSpring.rotationY}
+        rotation-z={dotSpring.rotationZ}
       >
         <GradientMat colorA="#34D399" colorB="#10B981" fresnelStrength={1.2} />
-      </animated.mesh>
+      </a.mesh>
     </>
   );
 }

--- a/components/three/Metaballs.tsx
+++ b/components/three/Metaballs.tsx
@@ -4,7 +4,7 @@ import { useFrame } from "@react-three/fiber";
 import { MarchingCubes, MarchingPlane } from "@react-three/drei";
 import { useMemo, useRef } from "react";
 import { Color } from "three";
-import type { MarchingCubes as MarchingCubesImpl } from "three/examples/jsm/objects/MarchingCubes";
+import type { MarchingCubes as MarchingCubesImpl } from "three/examples/jsm/objects/MarchingCubes.js";
 
 type Metaball = {
   color: Color;
@@ -53,9 +53,8 @@ export default function Metaballs() {
       resolution={32}
       maxPolyCount={12000}
       enableColors
-      isovalue={0.15}
     >
-      <MarchingPlane planeType="z" constant={-1} />
+      <MarchingPlane planeType="z" />
       <meshStandardMaterial vertexColors roughness={0.35} metalness={0.15} />
     </MarchingCubes>
   );

--- a/types/three-examples.d.ts
+++ b/types/three-examples.d.ts
@@ -1,0 +1,30 @@
+import * as THREE from "three";
+
+declare module "three/examples/jsm/objects/MarchingCubes.js" {
+  export class MarchingCubes extends THREE.ImmediateRenderObject {
+    constructor(
+      resolution: number,
+      material: THREE.Material,
+      enableUvs: boolean,
+      enableColors: boolean,
+      useNormals?: boolean,
+      useUvs?: boolean,
+    );
+    field: Float32Array;
+    enableUvs: boolean;
+    enableColors: boolean;
+    subtract: number;
+    strength: number;
+    addBall(
+      x: number,
+      y: number,
+      z: number,
+      strength: number,
+      subtract: number,
+      color?: THREE.Color,
+    ): void;
+    addPlane(x: number, y: number, z: number, strength: number, subtract: number): void;
+    reset(): void;
+    update(): void;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the floating nine-dot trigger and overlay to match the reference layout with gradients, numbered links, and social badges
- smooth out reusable button styles and fallback loader shadows while updating the metaballs overlay types and props for Tailwind 4
- add type declarations for three.js marching cubes and adjust procedural shape springs to satisfy TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d96ec7fed0832f905c37a60037848f