### PR TITLE
Add localized hero and sections for portfolio pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,11 +1,51 @@
-import Experience from '../../components/Experience';
-import Navbar from '../../components/Navbar';
+"use client";
+
+import Image from "next/image";
+import Experience from "../../components/Experience";
+import Navbar from "../../components/Navbar";
+import { useTranslation } from "react-i18next";
+import "../i18n/config";
 
 export default function AboutPage() {
+  const { t } = useTranslation();
+
   return (
     <>
       <Navbar />
-      <Experience variant="about" />
+      <main className="relative min-h-screen overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <Experience variant="about" />
+          <div className="absolute inset-0 bg-gradient-to-b from-bg/35 via-bg/80 to-bg" aria-hidden />
+        </div>
+        <div className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-16">
+          <section className="flex-1 space-y-6">
+            <p className="text-xs uppercase tracking-[0.4em] text-fg/60">
+              {t("about.kicker")}
+            </p>
+            <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+              {t("about.title")}
+            </h1>
+            <div className="space-y-4 text-base text-fg/80 sm:text-lg">
+              <p>{t("about.paragraphs.first")}</p>
+              <p>{t("about.paragraphs.second")}</p>
+              <p>{t("about.paragraphs.third")}</p>
+            </div>
+          </section>
+          <section className="flex flex-1 justify-center lg:justify-end">
+            <div className="relative h-80 w-80 overflow-hidden rounded-full border border-fg/20 bg-gradient-to-br from-fg/10 via-transparent to-transparent shadow-[0_20px_50px_-25px_rgba(0,0,0,0.6)]">
+              <Image
+                src="/images/about-portrait.svg"
+                alt={t("about.visualCaption")}
+                fill
+                className="object-cover"
+                sizes="320px"
+                priority
+              />
+              <div className="pointer-events-none absolute inset-0 bg-gradient-radial from-transparent via-transparent to-bg/20" aria-hidden />
+            </div>
+          </section>
+        </div>
+      </main>
     </>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,11 +1,89 @@
-import Experience from '../../components/Experience';
-import Navbar from '../../components/Navbar';
+"use client";
+
+import { FormEvent, useState } from "react";
+import Experience from "../../components/Experience";
+import Navbar from "../../components/Navbar";
+import { useTranslation } from "react-i18next";
+import "../i18n/config";
 
 export default function ContactPage() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<"idle" | "submitted">("idle");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    form.reset();
+    setStatus("submitted");
+  };
+
   return (
     <>
       <Navbar />
-      <Experience variant="contact" />
+      <main className="relative min-h-screen overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <Experience variant="contact" />
+          <div className="absolute inset-0 bg-gradient-to-b from-bg/45 via-bg/85 to-bg" aria-hidden />
+        </div>
+        <div className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left">
+          <div className="space-y-4">
+            <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+              {t("contact.title")}
+            </h1>
+            <p className="text-base text-fg/80 sm:text-lg">
+              {t("contact.subtitle")}
+            </p>
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)] backdrop-blur"
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
+                <span>{t("contact.form.nameLabel")}</span>
+                <input
+                  type="text"
+                  name="name"
+                  required
+                  className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+                  placeholder={t("contact.form.namePlaceholder")}
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
+                <span>{t("contact.form.emailLabel")}</span>
+                <input
+                  type="email"
+                  name="email"
+                  required
+                  className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+                  placeholder={t("contact.form.emailPlaceholder")}
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
+              <span>{t("contact.form.messageLabel")}</span>
+              <textarea
+                name="message"
+                required
+                rows={5}
+                className="rounded-3xl border border-fg/20 bg-transparent px-4 py-4 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+                placeholder={t("contact.form.messagePlaceholder")}
+              />
+            </label>
+            <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+              <button
+                type="submit"
+                className="w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
+              >
+                {t("contact.form.submit")}
+              </button>
+              <div className="min-h-[1.5rem] text-sm text-fg/70" aria-live="polite">
+                {status === "submitted" ? t("contact.form.success") : ""}
+              </div>
+            </div>
+          </form>
+        </div>
+      </main>
     </>
   );
 }

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -1,0 +1,157 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+const resources = {
+  pt: {
+    translation: {
+      home: {
+        kicker: "PORTFÓLIO DIGITAL DE DUARTOIS",
+        title: "Design generativo encontra experiências humanas.",
+        subtitle:
+          "Eu transformo dados, narrativas e ritmo visual em composições imersivas para marcas que querem se destacar em movimento.",
+        ctaProjects: "ver meus projetos",
+        ctaAbout: "mais sobre mim",
+      },
+      work: {
+        title: "Projetos selecionados",
+        subtitle:
+          "Passe o cursor ou use o teclado sobre cada projeto para explorar um preview do processo criativo.",
+        previewHint: "Preview dinâmico",
+        projects: {
+          aurora: {
+            title: "Aurora Chromatica",
+            year: "2024",
+            description:
+              "Experiência interativa que responde a trilhas sonoras em tempo real, gerando paisagens luminosas para um festival imersivo.",
+            previewAlt: "Visualização abstrata do projeto Aurora Chromatica.",
+          },
+          mare: {
+            title: "Maré Atlântica",
+            year: "2023",
+            description:
+              "Narrativa audiovisual que combina dados de marés e poesia para uma instalação em grande escala no litoral português.",
+            previewAlt: "Poster conceitual do projeto Maré Atlântica.",
+          },
+          spectrum: {
+            title: "Spectrum Pulse",
+            year: "2022",
+            description:
+              "Sistema de identidade modular para uma plataforma de música generativa, com diretrizes responsivas para print e motion.",
+            previewAlt: "Interface dinâmica do projeto Spectrum Pulse.",
+          },
+        },
+      },
+      about: {
+        kicker: "quem sou",
+        title: "Criativo multidisciplinar com foco em futuros visuais.",
+        paragraphs: {
+          first:
+            "Sou Duarte, designer e diretor criativo com raízes em Lisboa e atuação global. Trabalho na interseção entre storytelling, tecnologia e estética vibrante.",
+          second:
+            "Nos últimos anos liderei projetos para estúdios de motion, marcas culturais e startups, orquestrando experiências que misturam 3D, vídeo interativo e narrativa sonora.",
+          third:
+            "Quando não estou explorando novos shaders, ensino workshops sobre design generativo e colaboro com comunidades que impulsionam a criatividade luso-brasileira.",
+        },
+        visualCaption: "Retrato estilizado de Duarte, com textura digital.",
+      },
+      contact: {
+        title: "Vamos criar algo juntos?",
+        subtitle:
+          "Envie uma mensagem com o que você está planejando ou conecte-se pelas redes abaixo.",
+        form: {
+          nameLabel: "Nome",
+          namePlaceholder: "Ana Silva",
+          emailLabel: "E-mail",
+          emailPlaceholder: "voce@estudio.com",
+          messageLabel: "Mensagem",
+          messagePlaceholder: "Conte-me sobre o projeto, prazos e objetivos.",
+          submit: "enviar mensagem",
+          success: "Mensagem enviada! Vou responder em breve.",
+        },
+      },
+    },
+  },
+  en: {
+    translation: {
+      home: {
+        kicker: "DUARTOIS DIGITAL PORTFOLIO",
+        title: "Generative design meets human experiences.",
+        subtitle:
+          "I translate data, stories, and visual rhythm into immersive compositions for brands that want to stand out in motion.",
+        ctaProjects: "see my projects",
+        ctaAbout: "more about me",
+      },
+      work: {
+        title: "Selected projects",
+        subtitle:
+          "Hover or focus each project to explore a glimpse of the creative process.",
+        previewHint: "Dynamic preview",
+        projects: {
+          aurora: {
+            title: "Aurora Chromatica",
+            year: "2024",
+            description:
+              "Interactive experience reacting to live soundtracks, generating luminous landscapes for an immersive festival.",
+            previewAlt: "Abstract visualization of the Aurora Chromatica project.",
+          },
+          mare: {
+            title: "Atlantic Tide",
+            year: "2023",
+            description:
+              "Audiovisual narrative blending tide data and poetry for a large-scale installation on the Portuguese coast.",
+            previewAlt: "Concept poster for the Atlantic Tide project.",
+          },
+          spectrum: {
+            title: "Spectrum Pulse",
+            year: "2022",
+            description:
+              "Modular identity system for a generative music platform, with responsive guidelines for print and motion.",
+            previewAlt: "Dynamic interface of the Spectrum Pulse project.",
+          },
+        },
+      },
+      about: {
+        kicker: "about me",
+        title: "Multidisciplinary creative focused on visual futures.",
+        paragraphs: {
+          first:
+            "I'm Duarte, a designer and creative director born in Lisbon with a global practice. I work where storytelling, technology, and vibrant aesthetics converge.",
+          second:
+            "In recent years I've led projects for motion studios, cultural brands, and startups, orchestrating experiences that mix 3D, interactive video, and sound narrative.",
+          third:
+            "When I'm not exploring new shaders, I teach workshops on generative design and collaborate with communities that champion Luso-Brazilian creativity.",
+        },
+        visualCaption: "Stylized portrait of Duarte with digital texture.",
+      },
+      contact: {
+        title: "Shall we create something together?",
+        subtitle:
+          "Send a note with what you're planning or connect through the networks below.",
+        form: {
+          nameLabel: "Name",
+          namePlaceholder: "Alex Johnson",
+          emailLabel: "Email",
+          emailPlaceholder: "you@studio.com",
+          messageLabel: "Message",
+          messagePlaceholder: "Tell me about the project, timeline, and goals.",
+          submit: "send message",
+          success: "Message sent! I'll reply soon.",
+        },
+      },
+    },
+  },
+} as const;
+
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    resources,
+    lng: "pt",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+    supportedLngs: ["pt", "en"],
+    defaultNS: "translation",
+  });
+}
+
+export default i18n;
+export type AppTranslationKeys = keyof typeof resources.pt.translation;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,48 @@
-import Experience from '../components/Experience';
-import Navbar from '../components/Navbar';
+"use client";
+
+import Link from "next/link";
+import Experience from "../components/Experience";
+import Navbar from "../components/Navbar";
+import { useTranslation } from "react-i18next";
+import "./i18n/config";
 
 export default function HomePage() {
+  const { t } = useTranslation();
+
   return (
     <>
       <Navbar />
-      <Experience variant="home" />
+      <main className="relative min-h-screen overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <Experience variant="home" />
+          <div className="absolute inset-0 bg-gradient-to-b from-bg/40 via-bg/80 to-bg" aria-hidden />
+        </div>
+        <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-8 px-6 text-center sm:gap-10">
+          <p className="text-xs uppercase tracking-[0.4em] text-fg/60 sm:text-sm">
+            {t("home.kicker")}
+          </p>
+          <h1 className="text-balance text-4xl font-semibold leading-tight text-fg sm:text-5xl md:text-6xl">
+            {t("home.title")}
+          </h1>
+          <p className="max-w-2xl text-pretty text-base text-fg/80 sm:text-lg">
+            {t("home.subtitle")}
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/work"
+              className="rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+            >
+              {t("home.ctaProjects")}
+            </Link>
+            <Link
+              href="/about"
+              className="rounded-full border border-fg/30 px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-fg transition hover:border-fg/60 hover:bg-fg/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+            >
+              {t("home.ctaAbout")}
+            </Link>
+          </div>
+        </section>
+      </main>
     </>
   );
 }

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,11 +1,100 @@
-import Experience from '../../components/Experience';
-import Navbar from '../../components/Navbar';
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Experience from "../../components/Experience";
+import Navbar from "../../components/Navbar";
+import { useTranslation } from "react-i18next";
+import "../i18n/config";
+
+const projectOrder = ["aurora", "mare", "spectrum"] as const;
+
+type ProjectKey = (typeof projectOrder)[number];
+
+type ProjectPreview = {
+  id: ProjectKey;
+  type: "image" | "description";
+  imageSrc?: string;
+};
+
+const projectPreviews: ProjectPreview[] = [
+  { id: "aurora", type: "image", imageSrc: "/images/project-aurora.svg" },
+  { id: "mare", type: "description" },
+  { id: "spectrum", type: "image", imageSrc: "/images/project-spectrum.svg" },
+];
 
 export default function WorkPage() {
+  const { t } = useTranslation();
+  const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
+
+  const activePreview = projectPreviews.find((preview) => preview.id === activeProject)!;
+
   return (
     <>
       <Navbar />
-      <Experience variant="work" />
+      <main className="relative min-h-screen overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <Experience variant="work" />
+          <div className="absolute inset-0 bg-gradient-to-b from-bg/40 via-bg/85 to-bg" aria-hidden />
+        </div>
+        <div className="relative z-10 mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20">
+          <section className="lg:w-1/2">
+            <p className="text-xs uppercase tracking-[0.4em] text-fg/60">
+              {t("work.previewHint")}
+            </p>
+            <h1 className="mt-4 text-4xl font-semibold text-fg sm:text-5xl">
+              {t("work.title")}
+            </h1>
+            <p className="mt-6 max-w-xl text-base text-fg/80 sm:text-lg">
+              {t("work.subtitle")}
+            </p>
+            <ul className="mt-10 flex flex-col gap-3">
+              {projectOrder.map((projectKey) => (
+                <li key={projectKey}>
+                  <button
+                    type="button"
+                    onMouseEnter={() => setActiveProject(projectKey)}
+                    onFocus={() => setActiveProject(projectKey)}
+                    className={`flex w-full items-center justify-between gap-4 rounded-2xl border px-6 py-4 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:px-8 ${
+                      activeProject === projectKey
+                        ? "border-fg/60 bg-fg/10"
+                        : "border-fg/20 bg-bg/60 hover:border-fg/40 hover:bg-fg/5"
+                    }`}
+                  >
+                    <span className="text-lg font-semibold uppercase tracking-[0.3em] text-fg">
+                      {t(`work.projects.${projectKey}.title`)}
+                    </span>
+                    <span className="text-sm font-medium text-fg/60">
+                      {t(`work.projects.${projectKey}.year`)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+          <section className="relative flex w-full flex-1 items-center justify-center">
+            <div className="relative aspect-[4/3] w-full max-w-xl overflow-hidden rounded-3xl border border-fg/15 bg-bg/80 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.6)] backdrop-blur">
+              {activePreview.type === "image" && activePreview.imageSrc ? (
+                <Image
+                  src={activePreview.imageSrc}
+                  alt={t(`work.projects.${activePreview.id}.previewAlt`)}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 1024px) 80vw, 480px"
+                  priority
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center p-10">
+                  <p className="text-pretty text-lg text-fg/80">
+                    {t(`work.projects.${activePreview.id}.description`)}
+                  </p>
+                </div>
+              )}
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-transparent via-bg/20 to-bg/40" aria-hidden />
+            </div>
+          </section>
+        </div>
+      </main>
     </>
   );
 }

--- a/public/images/about-portrait.svg
+++ b/public/images/about-portrait.svg
@@ -1,0 +1,29 @@
+<svg width="640" height="640" viewBox="0 0 640 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="halo" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f1f2ff" stop-opacity="0.9" />
+      <stop offset="70%" stop-color="#9ba7ff" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#1a1f3f" stop-opacity="0.8" />
+    </radialGradient>
+    <linearGradient id="face" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffdeb8" />
+      <stop offset="100%" stop-color="#f9a678" />
+    </linearGradient>
+    <linearGradient id="hair" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f1c40" />
+      <stop offset="100%" stop-color="#34276c" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="640" rx="320" fill="#070b1f" />
+  <circle cx="320" cy="320" r="280" fill="url(#halo)" opacity="0.8" />
+  <path d="M200 240C220 180 280 160 320 160C360 160 420 180 440 240C460 300 420 420 320 420C220 420 180 300 200 240Z" fill="url(#hair)" />
+  <ellipse cx="320" cy="320" rx="120" ry="140" fill="url(#face)" />
+  <ellipse cx="280" cy="300" rx="22" ry="18" fill="#2f2a57" opacity="0.8" />
+  <ellipse cx="360" cy="300" rx="22" ry="18" fill="#2f2a57" opacity="0.8" />
+  <path d="M276 368C296 388 344 388 364 368" stroke="#d87f6c" stroke-width="10" stroke-linecap="round" />
+  <path d="M240 250C260 232 300 220 320 220C340 220 380 232 400 250" stroke="#0f1228" stroke-width="18" stroke-linecap="round" opacity="0.5" />
+  <g opacity="0.45">
+    <path d="M180 440C220 500 280 540 320 540C360 540 420 500 460 440" stroke="#ffffff" stroke-width="18" stroke-linecap="round" stroke-opacity="0.25" />
+    <path d="M160 460C210 520 280 560 320 560C360 560 430 520 480 460" stroke="#7ecbff" stroke-width="10" stroke-linecap="round" stroke-opacity="0.35" />
+  </g>
+</svg>

--- a/public/images/project-aurora.svg
+++ b/public/images/project-aurora.svg
@@ -1,0 +1,22 @@
+<svg width="960" height="720" viewBox="0 0 960 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#f8f6ff" stop-opacity="0.95" />
+      <stop offset="45%" stop-color="#8f7bff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#2a1b64" stop-opacity="0.9" />
+    </radialGradient>
+    <radialGradient id="pulse" cx="30%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#ffe8f6" stop-opacity="0.85" />
+      <stop offset="40%" stop-color="#ff7edb" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#2e0f4d" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="960" height="720" fill="#0b0c1f" />
+  <ellipse cx="460" cy="360" rx="420" ry="280" fill="url(#glow)" />
+  <circle cx="640" cy="240" r="200" fill="url(#pulse)" />
+  <circle cx="300" cy="480" r="150" fill="url(#pulse)" transform="rotate(-20 300 480)" />
+  <g opacity="0.3">
+    <path d="M120 580C240 460 360 520 520 480C680 440 780 320 840 220" stroke="#ffffff" stroke-opacity="0.6" stroke-width="6" stroke-linecap="round" />
+    <path d="M120 520C240 400 400 440 520 420C680 390 780 280 860 160" stroke="#9ee7ff" stroke-opacity="0.4" stroke-width="4" stroke-linecap="round" />
+  </g>
+</svg>

--- a/public/images/project-spectrum.svg
+++ b/public/images/project-spectrum.svg
@@ -1,0 +1,34 @@
+<svg width="960" height="720" viewBox="0 0 960 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="960" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#041424" />
+      <stop offset="50%" stop-color="#101f4b" />
+      <stop offset="100%" stop-color="#250c3c" />
+    </linearGradient>
+    <linearGradient id="band" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#66e4ff" />
+      <stop offset="40%" stop-color="#7d7dff" />
+      <stop offset="80%" stop-color="#ff8de2" />
+      <stop offset="100%" stop-color="#ffcd7d" />
+    </linearGradient>
+    <linearGradient id="bandSoft" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="720" fill="url(#background)" />
+  <g transform="rotate(-6 480 360)">
+    <rect x="-40" y="180" width="1040" height="120" rx="60" fill="url(#band)" opacity="0.9" />
+    <rect x="-20" y="320" width="1000" height="110" rx="55" fill="url(#bandSoft)" opacity="0.8" />
+    <rect x="0" y="460" width="960" height="100" rx="50" fill="url(#band)" opacity="0.7" />
+  </g>
+  <g opacity="0.25" stroke="#ffffff" stroke-width="1.2">
+    <path d="M120 140H840" />
+    <path d="M80 260H880" />
+    <path d="M120 380H840" />
+    <path d="M80 500H880" />
+    <path d="M120 620H840" />
+  </g>
+  <circle cx="780" cy="160" r="18" fill="#ff7ead" opacity="0.8" />
+  <circle cx="200" cy="580" r="26" fill="#5bd2ff" opacity="0.7" />
+</svg>


### PR DESCRIPTION
## Summary
- add a translated hero section with CTAs on the home page while keeping the 3D background
- implement an interactive work listing with localized project copy and illustrative assets
- expand the about and contact pages with translated content, a portrait visual, and a simple form backed by a shared i18n config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9773da0d4832f8d3bfed663b8f02b