### PR TITLE
Add internationalization support with language switcher

### DIFF
--- a/app/i18n/client.ts
+++ b/app/i18n/client.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import i18next, { Resource } from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import enCommon from "@/public/locales/en/common.json";
+import frCommon from "@/public/locales/fr/common.json";
+
+const resources = {
+  en: {
+    common: enCommon,
+  },
+  fr: {
+    common: frCommon,
+  },
+} satisfies Resource;
+
+if (!i18next.isInitialized) {
+  i18next.use(initReactI18next).init({
+    resources,
+    defaultNS: "common",
+    fallbackLng: "en",
+    supportedLngs: ["en", "fr"],
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+}
+
+export { useTranslation } from "react-i18next";
+export const i18n = i18next;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import AppShell from "@/components/AppShell";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <ThemeScript />
       </head>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect } from "react";
 import { Html } from "@react-three/drei";
 import Shapes from "./shapes/ProceduralShapes";
 import { useVariantStore } from "../store/variants";
+import { useTranslation } from "@/app/i18n/client";
 
 interface ExperienceProps {
   /**
@@ -18,6 +19,7 @@ interface ExperienceProps {
 
 export default function Experience({ variant }: ExperienceProps) {
   const setVariant = useVariantStore((state) => state.setVariant);
+  const { t } = useTranslation();
 
   // Whenever the variant prop changes, update the global store so that
   // animations can transition to the new values.  Because this is a
@@ -43,7 +45,7 @@ export default function Experience({ variant }: ExperienceProps) {
           fallback={
             <Html center>
               <div className="rounded-full bg-fg/10 px-6 py-3 text-sm font-medium text-fg/70 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)]">
-                Materializing shapes…
+                {t("experience.loading")}
               </div>
             </Html>
           }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ChangeEvent, useEffect } from "react";
+import { useTranslation } from "@/app/i18n/client";
+
+const SUPPORTED_LANGUAGES = ["en", "fr"] as const;
+
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export default function LanguageSwitcher() {
+  const { t, i18n: i18nextInstance } = useTranslation();
+  const currentLanguage = (i18nextInstance.language || "en").split("-")[0] as SupportedLanguage;
+
+  useEffect(() => {
+    document.documentElement.lang = currentLanguage;
+  }, [currentLanguage]);
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const newLanguage = event.target.value as SupportedLanguage;
+    if (SUPPORTED_LANGUAGES.includes(newLanguage) && newLanguage !== currentLanguage) {
+      i18nextInstance.changeLanguage(newLanguage);
+    }
+  };
+
+  return (
+    <label className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
+      <span>{t("languageSwitcher.label")}</span>
+      <select
+        value={currentLanguage}
+        onChange={handleChange}
+        className="rounded-full border border-fg/20 bg-transparent px-5 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.35em] text-fg transition hover:border-fg/40 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+        aria-label={t("languageSwitcher.label")}
+      >
+        <option value="en" className="bg-bg text-fg">
+          {t("languageSwitcher.languages.en")}
+        </option>
+        <option value="fr" className="bg-bg text-fg">
+          {t("languageSwitcher.languages.fr")}
+        </option>
+      </select>
+    </label>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import dynamic from "next/dynamic";
 import { Suspense, useEffect, useRef, useState } from "react";
+import { useTranslation } from "@/app/i18n/client";
+import LanguageSwitcher from "./LanguageSwitcher";
 
 const MetaballsCanvas = dynamic(() => import("./three/MetaballsCanvas"), {
   ssr: false,
@@ -12,10 +14,10 @@ const MetaballsCanvas = dynamic(() => import("./three/MetaballsCanvas"), {
 });
 
 const navigationLinks = [
-  { name: "home", href: "/" },
-  { name: "work", href: "/work" },
-  { name: "about", href: "/about" },
-  { name: "contact", href: "/contact" },
+  { key: "navbar.links.home", href: "/" },
+  { key: "navbar.links.work", href: "/work" },
+  { key: "navbar.links.about", href: "/about" },
+  { key: "navbar.links.contact", href: "/contact" },
 ] as const;
 
 const socialLinks = [
@@ -31,6 +33,7 @@ export default function Navbar() {
   const firstLinkRef = useRef<HTMLAnchorElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const hasOpenedRef = useRef(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (isOpen) {
@@ -76,7 +79,9 @@ export default function Navbar() {
         aria-controls="main-navigation-overlay"
         className="group fixed right-6 top-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-fg/20 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition hover:border-fg/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
       >
-        <span className="sr-only">{isOpen ? "Fechar navegação" : "Abrir navegação"}</span>
+        <span className="sr-only">
+          {isOpen ? t("navbar.closeNavigation") : t("navbar.openNavigation")}
+        </span>
         <span aria-hidden="true" className="grid grid-cols-3 gap-1.5">
           {Array.from({ length: 9 }).map((_, index) => (
             <motion.span
@@ -143,7 +148,7 @@ export default function Navbar() {
                   animate={{ y: 0, opacity: 1 }}
                   transition={{ delay: 0.1, duration: 0.3 }}
                 >
-                  Menu
+                  {t("navbar.menu")}
                 </motion.span>
                 <motion.button
                   type="button"
@@ -153,7 +158,7 @@ export default function Navbar() {
                   animate={{ y: 0, opacity: 1 }}
                   transition={{ delay: 0.15, duration: 0.3 }}
                 >
-                  Close
+                  {t("navbar.close")}
                 </motion.button>
               </header>
 
@@ -170,7 +175,7 @@ export default function Navbar() {
                       },
                     }}
                   >
-                    {navigationLinks.map(({ name, href }, index) => (
+                    {navigationLinks.map(({ key, href }, index) => (
                       <motion.li
                         key={href}
                         variants={{
@@ -186,7 +191,9 @@ export default function Navbar() {
                         >
                           <span className="text-sm font-normal tracking-[0.4em] text-fg/40">0{index + 1}</span>
                           <span className="relative">
-                            <span className="block transition duration-300 ease-out group-hover:-translate-y-1">{name}</span>
+                          <span className="block transition duration-300 ease-out group-hover:-translate-y-1">
+                            {t(key)}
+                          </span>
                             <span className="absolute inset-x-0 bottom-0 h-[3px] origin-left scale-x-0 bg-fg/80 transition-transform duration-300 ease-out group-hover:scale-x-100" />
                           </span>
                         </Link>
@@ -202,7 +209,7 @@ export default function Navbar() {
                   transition={{ delay: 0.35, duration: 0.4 }}
                 >
                   <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
-                    <span>Social</span>
+                    <span>{t("navbar.social")}</span>
                     <div className="h-px w-16 bg-fg/20" />
                   </div>
                   <div className="flex flex-wrap gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.35em]">
@@ -219,6 +226,7 @@ export default function Navbar() {
                       </Link>
                     ))}
                   </div>
+                  <LanguageSwitcher />
                 </motion.div>
               </div>
             </motion.div>

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import { useProgress } from "@react-three/drei";
+import { useTranslation } from "@/app/i18n/client";
 
 const MetaballsCanvas = dynamic(() => import("./three/MetaballsCanvas"), {
   ssr: false,
@@ -17,6 +18,7 @@ export default function Preloader({ onComplete }: PreloaderProps) {
   const { progress, active } = useProgress();
   const hasCompletedRef = useRef(false);
   const formattedProgress = Math.round(progress);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!active && !hasCompletedRef.current) {
@@ -37,7 +39,7 @@ export default function Preloader({ onComplete }: PreloaderProps) {
         </div>
       </Suspense>
       <div className="text-center text-fg">
-        <p className="text-lg font-semibold tracking-wide">Materializing shapes…</p>
+        <p className="text-lg font-semibold tracking-wide">{t("experience.loading")}</p>
         <p className="mt-1 text-sm font-medium text-fg/70">{formattedProgress}%</p>
       </div>
     </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,14 +1,16 @@
 "use client";
+import { useTranslation } from "@/app/i18n/client";
 import { useTheme } from "../app/lib/useTheme";
 
 export default function ThemeToggle() {
+  const { t } = useTranslation();
   const { theme, toggle } = useTheme();
   return (
     <button
       onClick={toggle}
       className="btn-secondary h-9 px-3 rounded-lg"
-      aria-label="Alternar tema"
-      title="Alternar tema"
+      aria-label={t("themeToggle.label")}
+      title={t("themeToggle.label")}
     >
       {theme === "dark" ? "🌙" : "☀️"}
     </button>

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,9 @@
+const path = require("path");
+
+module.exports = {
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "fr"],
+  },
+  localePath: path.resolve("./public/locales"),
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
+const { i18n } = require("./next-i18next.config");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  i18n,
 };
 
 module.exports = nextConfig;

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,28 @@
+{
+  "navbar": {
+    "menu": "Menu",
+    "openNavigation": "Open navigation",
+    "closeNavigation": "Close navigation",
+    "close": "Close",
+    "social": "Social",
+    "links": {
+      "home": "Home",
+      "work": "Work",
+      "about": "About",
+      "contact": "Contact"
+    }
+  },
+  "experience": {
+    "loading": "Materializing shapes…"
+  },
+  "languageSwitcher": {
+    "label": "Language",
+    "languages": {
+      "en": "English",
+      "fr": "French"
+    }
+  },
+  "themeToggle": {
+    "label": "Toggle theme"
+  }
+}

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,28 @@
+{
+  "navbar": {
+    "menu": "Menu",
+    "openNavigation": "Ouvrir la navigation",
+    "closeNavigation": "Fermer la navigation",
+    "close": "Fermer",
+    "social": "Réseaux sociaux",
+    "links": {
+      "home": "Accueil",
+      "work": "Portfolio",
+      "about": "À propos",
+      "contact": "Contact"
+    }
+  },
+  "experience": {
+    "loading": "Matérialisation des formes…"
+  },
+  "languageSwitcher": {
+    "label": "Langue",
+    "languages": {
+      "en": "Anglais",
+      "fr": "Français"
+    }
+  },
+  "themeToggle": {
+    "label": "Changer de thème"
+  }
+}


### PR DESCRIPTION
## Summary
- configure next-i18next with English and French locales and load the resources at build time
- add a client i18n setup with a language switcher component that updates the document language
- replace hardcoded UI copy with translation lookups in navigation, loaders, and the theme toggle

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d961bc9340832fbeba6f4112e57c4d