### PR TITLE
Move three.js components under components/three and load canvas dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ lighting effect, matching the glossy “blob” aesthetic of the original site.
 
 3. **Editing shapes**
 
-   The file at `components/shapes/ProceduralShapes.tsx` defines helper
+   The file at `components/three/ProceduralShapes.tsx` defines helper
    functions for creating each shape.  You can experiment with
    different geometries by changing the radius, tube thickness or the
    control points used for the `CatmullRomCurve3` S‑shape.  The

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import Image from "next/image";
-import Experience from "../../components/Experience";
+import dynamic from "next/dynamic";
 import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
+
+const Experience = dynamic(
+  () => import("../../components/three/Experience"),
+  { ssr: false }
+);
 
 export default function AboutPage() {
   const { t } = useTranslation();

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import Experience from "../../components/Experience";
+import dynamic from "next/dynamic";
 import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
+
+const Experience = dynamic(
+  () => import("../../components/three/Experience"),
+  { ssr: false }
+);
 
 export default function ContactPage() {
   const { t } = useTranslation();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
-import Experience from "../components/Experience";
 import Navbar from "../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
+
+const Experience = dynamic(() => import("../components/three/Experience"), {
+  ssr: false,
+});
 
 export default function HomePage() {
   const { t } = useTranslation();

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -2,10 +2,15 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Experience from "../../components/Experience";
+import dynamic from "next/dynamic";
 import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
+
+const Experience = dynamic(
+  () => import("../../components/three/Experience"),
+  { ssr: false }
+);
 
 const projectOrder = ["aurora", "mare", "spectrum"] as const;
 

--- a/components/three/Experience.tsx
+++ b/components/three/Experience.tsx
@@ -3,8 +3,8 @@
 import { Canvas } from "@react-three/fiber";
 import { Suspense, useEffect } from "react";
 import { Html } from "@react-three/drei";
-import Shapes from "./shapes/ProceduralShapes";
-import { useVariantStore } from "../store/variants";
+import Shapes from "./ProceduralShapes";
+import { useVariantStore } from "../../store/variants";
 
 interface ExperienceProps {
   /**

--- a/components/three/ProceduralShapes.tsx
+++ b/components/three/ProceduralShapes.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useMemo } from 'react';
-import { CatmullRomCurve3, TorusGeometry, TubeGeometry, SphereGeometry, Vector3 } from 'three';
-import type { Vector3Tuple } from 'three';
-import { a, useSpring } from '@react-spring/three';
-import { useVariantStore } from '../../store/variants';
-import GradientMat from '../../materials/GradientMat';
+import { useMemo } from "react";
+import {
+  CatmullRomCurve3,
+  TorusGeometry,
+  TubeGeometry,
+  SphereGeometry,
+  Vector3,
+} from "three";
+import type { Vector3Tuple } from "three";
+import { a, useSpring } from "@react-spring/three";
+import { useVariantStore } from "../../store/variants";
+import GradientMat from "../../materials/GradientMat";
 
 /**
  * Procedurally generates and animates the monogram shapes.  Each shape


### PR DESCRIPTION
## Summary
- relocate the Experience canvas and ProceduralShapes modules into the components/three directory alongside other 3D helpers
- load the Experience canvas with next/dynamic across the top-level pages so the three.js scene only renders client-side while keeping Suspense fallback behavior intact
- update documentation to reference the new ProceduralShapes path

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d983192474832f830fa4c10e05b488