### PR TITLE
Refresh pastel palette and theme colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,30 +1,30 @@
 @import "tailwindcss";
 
 :root {
-  --bg: 0 0 0;        /* preto */
-  --fg: 255 255 255;  /* branco */
-  --muted: 160 160 160;
+  --color-bg: 244 247 255;      /* fallback pastel sky */
+  --color-fg: 30 36 46;         /* suave e legível */
+  --color-muted: 122 136 158;   /* detalhes discretos */
 }
 
 /* Modo claro */
 :root[data-theme="light"], :root.light {
-  --bg: 250 250 255;
-  --fg: 15 18 22;
-  --muted: 100 110 125;
+  --color-bg: 244 247 255;      /* fundo pastel azulado */
+  --color-fg: 28 32 45;         /* texto levemente frio */
+  --color-muted: 130 142 164;   /* elementos secundários */
 }
 
 /* Modo escuro */
 :root[data-theme="dark"], :root.dark {
-  --bg: 0 0 0;
-  --fg: 255 255 255;
-  --muted: 160 160 160;
+  --color-bg: 6 8 12;           /* preto profundo */
+  --color-fg: 230 236 250;      /* texto claro vívido */
+  --color-muted: 140 154 174;   /* destaque suave em contraste */
 }
 
 /* 2) Reset & base */
 html, body, #__next { height: 100% }
 html, body {
-  background: rgb(var(--bg));
-  color: rgb(var(--fg));
+  background: rgb(var(--color-bg));
+  color: rgb(var(--color-fg));
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -37,8 +37,8 @@ html, body {
 }
 .btn-secondary {
   @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
-  background: rgb(var(--fg) / 0.07);
-  color: rgb(var(--fg));
+  background: rgb(var(--color-fg) / 0.07);
+  color: rgb(var(--color-fg));
 }
 .link {
   @apply underline underline-offset-4 decoration-transparent hover:decoration-current transition-colors duration-300 ease-[cubic-bezier(.22,.61,.36,1)];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,42 +15,57 @@ const config: Config = {
       },
       colors: {
         // Paleta base em cima de variáveis (permite trocar tema sem rebuild)
-        bg: "rgb(var(--bg) / <alpha-value>)",
-        fg: "rgb(var(--fg) / <alpha-value>)",
-        muted: "rgb(var(--muted) / <alpha-value>)",
-        // Paleta “Sharlee vibes” para gradientes/materiais
+        bg: "rgb(var(--color-bg) / <alpha-value>)",
+        fg: "rgb(var(--color-fg) / <alpha-value>)",
+        muted: "rgb(var(--color-muted) / <alpha-value>)",
+        // Rampas pastéis para os novos acentos do tema
         brand: {
-          50:  "#eef3ff",
-          100: "#d7e4ff",
-          200: "#b9d2ff",
-          300: "#93b8ff",
-          400: "#7ab6ff",
-          500: "#4b8dff",
-          600: "#2a63e6",
-          700: "#1f49b3",
-          800: "#193a8f",
-          900: "#142e73"
+          50: "#f4ffe7",
+          100: "#e8ffc8",
+          200: "#d4ff9d",
+          300: "#b6f972",
+          400: "#9ae752",
+          500: "#6ecd29",
+          600: "#4da01f",
+          700: "#37781b",
+          800: "#285c18",
+          900: "#1e4715"
         },
-        candy: {
-          50:  "#fff1f6",
-          100: "#ffd6e7",
-          300: "#ff9cc7",
-          500: "#ff5fa7",
-          700: "#e23d8b"
+        accent1: {
+          50: "#fff5fa",
+          100: "#ffe7f2",
+          200: "#ffcee4",
+          300: "#ffafd1",
+          400: "#ff8fbb",
+          500: "#f96aa7",
+          600: "#df4c8b",
+          700: "#b8366d",
+          800: "#8e274f",
+          900: "#6c1d3b"
         },
-        lime: {
-          50:  "#eeffef",
-          100: "#e8ffd1",
-          300: "#b8f9b0",
-          500: "#62ff9a",
-          700: "#28b56f"
+        accent2: {
+          50: "#f9f5ff",
+          100: "#f1e8ff",
+          200: "#e3d4ff",
+          300: "#ceb5ff",
+          400: "#b391f6",
+          500: "#9472dd",
+          600: "#7657bd",
+          700: "#5c4395",
+          800: "#443171",
+          900: "#322456"
         },
-        amber: {
-          50:  "#fff9e8",
-          100: "#fff7cc",
-          300: "#ffea85",
-          500: "#ffd262",
-          700: "#d1a53b"
+        accent3: {
+          50: "#e8fffc",
+          100: "#c8fff4",
+          200: "#99f7ea",
+          300: "#6ae7dd",
+          400: "#3ecfd0",
+          500: "#1fb0ba",
+          600: "#188c99",
+          700: "#136d79",
+          800: "#0f535e",
+          900: "#0b4048"
         }
       },
       // sombras e transições suaves


### PR DESCRIPTION
## Summary
- replace the previous brand and accent ramps with pastel-focused brand/accent palettes aligned to lime, pink, lilac, and aqua hues
- retarget the bg/fg/muted tokens and global CSS variables to use the new palette in both light and dark themes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d9c1eed2dc832fa674dbe98f26baeb