### PR TITLE
Adjust overlay gradients for better theme contrast

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -20,7 +20,10 @@ export default function AboutPage() {
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10">
           <Experience variant="about" />
-          <div className="absolute inset-0 bg-gradient-to-b from-bg/35 via-bg/80 to-bg" aria-hidden />
+          <div
+            className="absolute inset-0 bg-gradient-to-b from-accent1-200/60 via-bg/70 to-bg dark:from-accent1-700/35 dark:via-bg/80 dark:to-bg"
+            aria-hidden
+          />
         </div>
         <div className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-16">
           <section className="flex-1 space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,10 @@ export default function HomePage() {
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10">
           <Experience variant="home" />
-          <div className="absolute inset-0 bg-gradient-to-b from-bg/40 via-bg/80 to-bg" aria-hidden />
+          <div
+            className="absolute inset-0 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg"
+            aria-hidden
+          />
         </div>
         <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-8 px-6 text-center sm:gap-10">
           <p className="text-xs uppercase tracking-[0.4em] text-fg/60 sm:text-sm">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -40,7 +40,10 @@ export default function WorkPage() {
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10">
           <Experience variant="work" />
-          <div className="absolute inset-0 bg-gradient-to-b from-bg/40 via-bg/85 to-bg" aria-hidden />
+          <div
+            className="absolute inset-0 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg"
+            aria-hidden
+          />
         </div>
         <div className="relative z-10 mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20">
           <section className="lg:w-1/2">


### PR DESCRIPTION
## Summary
- soften the hero overlays on the home, about, and work pages with pastel brand stops in light mode
- tune dark theme gradients to keep the 3D canvas readable while preserving depth

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68d9c8f06648832fa286c360661c883b