### PR TITLE
feat: replace hero experience with organic shape

### DIFF
--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -5,12 +5,14 @@ const resources = {
   pt: {
     translation: {
       home: {
-        kicker: "PORTFÓLIO DIGITAL DE DUARTOIS",
-        title: "Design generativo encontra experiências humanas.",
-        subtitle:
-          "Eu transformo dados, narrativas e ritmo visual em composições imersivas para marcas que querem se destacar em movimento.",
-        ctaProjects: "ver meus projetos",
-        ctaAbout: "mais sobre mim",
+        hero: {
+          kicker: "PORTFÓLIO DIGITAL DE DUARTOIS",
+          title: "Identidades cinéticas para marcas visionárias.",
+          subtitle:
+            "Crio narrativas digitais que unem arte generativa, movimento e som para lançar experiências inesquecíveis.",
+          ctaProjects: "ver meus projetos",
+          ctaAbout: "mais sobre mim",
+        },
       },
       work: {
         title: "Projetos selecionados",
@@ -74,12 +76,14 @@ const resources = {
   en: {
     translation: {
       home: {
-        kicker: "DUARTOIS DIGITAL PORTFOLIO",
-        title: "Generative design meets human experiences.",
-        subtitle:
-          "I translate data, stories, and visual rhythm into immersive compositions for brands that want to stand out in motion.",
-        ctaProjects: "see my projects",
-        ctaAbout: "more about me",
+        hero: {
+          kicker: "DUARTOIS DIGITAL PORTFOLIO",
+          title: "Kinetic identities for vision-led brands.",
+          subtitle:
+            "I craft digital narratives that blend generative art, motion, and sound to launch unforgettable experiences.",
+          ctaProjects: "see my projects",
+          ctaAbout: "more about me",
+        },
       },
       work: {
         title: "Selected projects",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,18 @@
 
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import { Suspense } from "react";
+import { Canvas } from "@react-three/fiber";
 import Navbar from "../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
-const Experience = dynamic(() => import("../components/three/Experience"), {
-  ssr: false,
-});
+const OrganicShape = dynamic(
+  () => import("../components/three/OrganicShape"),
+  {
+    ssr: false,
+  },
+);
 
 export default function HomePage() {
   const { t } = useTranslation();
@@ -18,7 +23,18 @@ export default function HomePage() {
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10">
-          <Experience variant="home" />
+          <Canvas
+            camera={{ position: [0, 0, 6], fov: 42 }}
+            gl={{ antialias: true, alpha: true }}
+            dpr={[1, 2]}
+            className="h-full w-full"
+          >
+            <ambientLight intensity={0.5} />
+            <directionalLight position={[5, 6, 8]} intensity={1.2} />
+            <Suspense fallback={null}>
+              <OrganicShape variant="hero" colorScheme="brand" />
+            </Suspense>
+          </Canvas>
           <div
             className="absolute inset-0 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg"
             aria-hidden
@@ -26,26 +42,26 @@ export default function HomePage() {
         </div>
         <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-8 px-6 text-center sm:gap-10">
           <p className="text-xs uppercase tracking-[0.4em] text-fg/60 sm:text-sm">
-            {t("home.kicker")}
+            {t("home.hero.kicker")}
           </p>
           <h1 className="text-balance text-4xl font-semibold leading-tight text-fg sm:text-5xl md:text-6xl">
-            {t("home.title")}
+            {t("home.hero.title")}
           </h1>
           <p className="max-w-2xl text-pretty text-base text-fg/80 sm:text-lg">
-            {t("home.subtitle")}
+            {t("home.hero.subtitle")}
           </p>
           <div className="flex flex-col gap-3 sm:flex-row">
             <Link
               href="/work"
               className="rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
             >
-              {t("home.ctaProjects")}
+              {t("home.hero.ctaProjects")}
             </Link>
             <Link
               href="/about"
               className="rounded-full border border-fg/30 px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-fg transition hover:border-fg/60 hover:bg-fg/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
             >
-              {t("home.ctaAbout")}
+              {t("home.hero.ctaAbout")}
             </Link>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- swap the hero background to a Canvas-rendered OrganicShape loaded dynamically without SSR
- extend the OrganicShape component with a hero variant and brand color palette for the homepage
- restructure the home hero translations with refreshed title and subtitle copy in both locales

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d9d5eee264832fa065a512398f5fb4