### PR TITLE
feat: refresh about page visuals and copy

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,15 +1,21 @@
 "use client";
 
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import Navbar from "../../components/Navbar";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
+import Link from "next/link";
+import { Suspense } from "react";
+import { Canvas } from "@react-three/fiber";
 import "../i18n/config";
 
-const Experience = dynamic(
-  () => import("../../components/three/Experience"),
-  { ssr: false }
+const OrganicShape = dynamic(
+  () => import("../../components/three/OrganicShape"),
+  { ssr: false },
 );
+
+const AvatarOrb = dynamic(() => import("../../components/three/AvatarOrb"), {
+  ssr: false,
+});
 
 export default function AboutPage() {
   const { t } = useTranslation();
@@ -19,9 +25,20 @@ export default function AboutPage() {
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10">
-          <Experience variant="about" />
+          <Canvas
+            camera={{ position: [0, 0, 6], fov: 42 }}
+            gl={{ antialias: true, alpha: true }}
+            dpr={[1, 2]}
+            className="h-full w-full"
+          >
+            <ambientLight intensity={0.5} />
+            <directionalLight position={[5, 6, 8]} intensity={1.2} />
+            <Suspense fallback={null}>
+              <OrganicShape variant="torusKnot" colorScheme="lagoon" />
+            </Suspense>
+          </Canvas>
           <div
-            className="absolute inset-0 bg-gradient-to-b from-accent1-200/60 via-bg/70 to-bg dark:from-accent1-700/35 dark:via-bg/80 dark:to-bg"
+            className="absolute inset-0 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg"
             aria-hidden
           />
         </div>
@@ -36,21 +53,25 @@ export default function AboutPage() {
             <div className="space-y-4 text-base text-fg/80 sm:text-lg">
               <p>{t("about.paragraphs.first")}</p>
               <p>{t("about.paragraphs.second")}</p>
-              <p>{t("about.paragraphs.third")}</p>
+              <p>
+                <Trans
+                  i18nKey="about.paragraphs.third"
+                  components={{
+                    github: (
+                      <Link
+                        href="https://github.com/Duartois"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-semibold text-fg underline decoration-dotted underline-offset-4 transition hover:text-fg/80"
+                      />
+                    ),
+                  }}
+                />
+              </p>
             </div>
           </section>
           <section className="flex flex-1 justify-center lg:justify-end">
-            <div className="relative h-80 w-80 overflow-hidden rounded-full border border-fg/20 bg-gradient-to-br from-fg/10 via-transparent to-transparent shadow-[0_20px_50px_-25px_rgba(0,0,0,0.6)]">
-              <Image
-                src="/images/about-portrait.svg"
-                alt={t("about.visualCaption")}
-                fill
-                className="object-cover"
-                sizes="320px"
-                priority
-              />
-              <div className="pointer-events-none absolute inset-0 bg-gradient-radial from-transparent via-transparent to-bg/20" aria-hidden />
-            </div>
+            <AvatarOrb />
           </section>
         </div>
       </main>

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -48,13 +48,13 @@ const resources = {
         title: "Criativo multidisciplinar com foco em futuros visuais.",
         paragraphs: {
           first:
-            "Sou Duarte, designer e diretor criativo com raízes em Lisboa e atuação global. Trabalho na interseção entre storytelling, tecnologia e estética vibrante.",
+            "Sou Duarte, designer e diretor criativo com raízes em Lisboa e atuação global. Transformo conceitos em experiências digitais unindo JavaScript, React e Three.js à direção de arte cinematográfica.",
           second:
-            "Nos últimos anos liderei projetos para estúdios de motion, marcas culturais e startups, orquestrando experiências que misturam 3D, vídeo interativo e narrativa sonora.",
+            "No estúdio aplico processos ágeis: prototipagem com Tailwind, integrações Stripe, desenho de APIs e modelagem de dados em MongoDB para escalar produtos expressivos.",
           third:
-            "Quando não estou explorando novos shaders, ensino workshops sobre design generativo e colaboro com comunidades que impulsionam a criatividade luso-brasileira.",
+            "Entre colaborações sigo estudando som, motion e design generativo — explore meu <github>GitHub</github> (@Duartois) para ver protótipos vivos e ferramentas abertas.",
         },
-        visualCaption: "Retrato estilizado de Duarte, com textura digital.",
+        visualCaption: "Avatar orgânico animado representando Duarte.",
       },
       contact: {
         title: "Vamos criar algo juntos?",
@@ -119,13 +119,13 @@ const resources = {
         title: "Multidisciplinary creative focused on visual futures.",
         paragraphs: {
           first:
-            "I'm Duarte, a designer and creative director born in Lisbon with a global practice. I work where storytelling, technology, and vibrant aesthetics converge.",
+            "I'm Duarte, a designer and creative director from Lisbon with a global practice. I turn concepts into digital experiences by pairing JavaScript, React, and Three.js with cinematic art direction.",
           second:
-            "In recent years I've led projects for motion studios, cultural brands, and startups, orchestrating experiences that mix 3D, interactive video, and sound narrative.",
+            "Inside the studio I lean on agile workflows — rapid prototyping with Tailwind, Stripe integrations, API design, and MongoDB data modelling to ship expressive products.",
           third:
-            "When I'm not exploring new shaders, I teach workshops on generative design and collaborate with communities that champion Luso-Brazilian creativity.",
+            "When I'm not co-creating with teams, I'm studying sound, motion, and generative design — browse my <github>GitHub</github> (@Duartois) to see living prototypes and open tools.",
         },
-        visualCaption: "Stylized portrait of Duarte with digital texture.",
+        visualCaption: "Animated organic avatar representing Duarte.",
       },
       contact: {
         title: "Shall we create something together?",

--- a/components/three/AvatarOrb.tsx
+++ b/components/three/AvatarOrb.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Suspense, useMemo, useRef } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { Html } from "@react-three/drei";
+import { useReducedMotion } from "framer-motion";
+import { Color, Group, Mesh } from "three";
+
+function OrbitingSpark({
+  radius,
+  speed,
+  delay,
+  reduceMotion,
+}: {
+  radius: number;
+  speed: number;
+  delay: number;
+  reduceMotion: boolean;
+}) {
+  const groupRef = useRef<Group | null>(null);
+  const sparkRef = useRef<Mesh | null>(null);
+
+  useFrame(({ clock }) => {
+    const time = clock.getElapsedTime();
+
+    const group = groupRef.current;
+    if (group && !reduceMotion) {
+      const t = time * speed + delay;
+      group.rotation.y = t;
+      group.rotation.x = Math.sin(t * 0.6) * 0.35;
+    }
+
+    const spark = sparkRef.current;
+    if (spark) {
+      spark.position.set(radius, 0, 0);
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      <mesh ref={sparkRef}>
+        <sphereGeometry args={[0.12, 24, 24]} />
+        <meshStandardMaterial
+          color="#f5f2ff"
+          emissive="#86a4ff"
+          emissiveIntensity={0.8}
+          metalness={0.25}
+          roughness={0.2}
+          toneMapped={false}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function AvatarCore({ reduceMotion }: { reduceMotion: boolean }) {
+  const shellRef = useRef<Mesh | null>(null);
+  const coreRef = useRef<Mesh | null>(null);
+
+  const colors = useMemo(
+    () => ({
+      core: new Color("#f2d4ff"),
+      coreEmissive: new Color("#7289ff"),
+      shell: new Color("#95c8ff"),
+      shellEmissive: new Color("#70a2ff"),
+    }),
+    [],
+  );
+
+  useFrame(({ clock }) => {
+    const time = clock.getElapsedTime();
+
+    if (!reduceMotion) {
+      const shell = shellRef.current;
+      if (shell) {
+        shell.rotation.x = Math.sin(time * 0.35) * 0.4;
+        shell.rotation.y = time * 0.45;
+        shell.rotation.z = Math.sin(time * 0.25) * 0.3;
+      }
+
+      const core = coreRef.current;
+      if (core) {
+        core.rotation.x = Math.cos(time * 0.4) * 0.25;
+        core.rotation.y = time * 0.35;
+        core.rotation.z = Math.sin(time * 0.45) * 0.2;
+      }
+    }
+  });
+
+  return (
+    <group>
+      <mesh ref={shellRef} castShadow receiveShadow>
+        <icosahedronGeometry args={[1.4, 2]} />
+        <meshStandardMaterial
+          color={colors.shell}
+          emissive={colors.shellEmissive}
+          emissiveIntensity={0.55}
+          roughness={0.35}
+          metalness={0.15}
+          transparent
+          opacity={0.75}
+          envMapIntensity={0.8}
+          toneMapped={false}
+        />
+      </mesh>
+      <mesh ref={coreRef} castShadow receiveShadow>
+        <icosahedronGeometry args={[1, 1]} />
+        <meshStandardMaterial
+          color={colors.core}
+          emissive={colors.coreEmissive}
+          emissiveIntensity={0.42}
+          roughness={0.28}
+          metalness={0.18}
+          envMapIntensity={0.9}
+          toneMapped={false}
+        />
+      </mesh>
+      <OrbitingSpark radius={1.9} speed={0.6} delay={0} reduceMotion={reduceMotion} />
+      <OrbitingSpark radius={1.9} speed={-0.45} delay={Math.PI / 2} reduceMotion={reduceMotion} />
+    </group>
+  );
+}
+
+export default function AvatarOrb() {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div className="relative h-80 w-80 overflow-hidden rounded-full border border-fg/20 bg-gradient-to-br from-fg/10 via-transparent to-transparent shadow-[0_20px_50px_-25px_rgba(0,0,0,0.6)]">
+      <Canvas
+        camera={{ position: [0, 0, 5], fov: 40 }}
+        dpr={[1, 2]}
+        gl={{ antialias: true, alpha: true }}
+      >
+        <color attach="background" args={["transparent"]} />
+        <ambientLight intensity={0.55} />
+        <directionalLight position={[4, 6, 8]} intensity={1.2} />
+        <Suspense
+          fallback={
+            <Html center>
+              <div className="rounded-full bg-fg/10 px-4 py-2 text-xs font-medium uppercase tracking-[0.3em] text-fg/70 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)]">
+                Loading avatar…
+              </div>
+            </Html>
+          }
+        >
+          <AvatarCore reduceMotion={Boolean(shouldReduceMotion)} />
+        </Suspense>
+      </Canvas>
+      <div className="pointer-events-none absolute inset-0 bg-gradient-radial from-transparent via-transparent to-bg/20" aria-hidden />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the about page background with a torus-knot OrganicShape canvas and add the new AvatarOrb hero asset that honors reduced-motion preferences
- rewrite the about body copy in both locales to spotlight JavaScript, React, Three.js, Tailwind, Stripe, API, and MongoDB expertise while linking to the Duartois GitHub profile
- introduce the reusable AvatarOrb three.js component for the animated avatar presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9deabb714832f8a54c0cbfe5b39f3