### PR TITLE
Refactor navbar overlay to use organic backdrop

### DIFF
--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import { Suspense, type RefObject } from "react";
+
+const OrganicShape = dynamic(() => import("./three/OrganicShape"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-full w-full animate-pulse rounded-full bg-accent2-200/20" />
+  ),
+});
+
+type NavigationLink = {
+  name: string;
+  href: string;
+};
+
+type SocialLink = {
+  label: string;
+  href: string;
+};
+
+type NavOverlayProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  firstLinkRef: RefObject<HTMLAnchorElement>;
+  navigationLinks: readonly NavigationLink[];
+  socialLinks: readonly SocialLink[];
+  overlayRef: RefObject<HTMLDivElement>;
+};
+
+export default function NavOverlay({
+  isOpen,
+  onClose,
+  firstLinkRef,
+  navigationLinks,
+  socialLinks,
+  overlayRef,
+}: NavOverlayProps) {
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          ref={overlayRef}
+          id="main-navigation-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="main-navigation-title"
+          tabIndex={-1}
+          className="fixed inset-0 z-40 overflow-hidden"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.25, ease: "easeInOut" }}
+        >
+          <motion.div
+            className="absolute inset-0 bg-gradient-to-br from-brand-900 via-accent2-900/90 to-accent3-900"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.35, ease: "easeInOut" }}
+          />
+          <div className="pointer-events-none absolute inset-0 opacity-35 mix-blend-screen">
+            <Suspense fallback={null}>
+              <div className="absolute left-1/2 top-1/2 h-[min(60vh,32rem)] w-[min(60vh,32rem)] -translate-x-1/2 -translate-y-1/2 blur-sm">
+                <OrganicShape variant="marchingCubes" colorScheme="brand" />
+              </div>
+            </Suspense>
+          </div>
+
+          <motion.div
+            className="relative z-10 flex h-full w-full flex-col"
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 24 }}
+            transition={{ duration: 0.35, ease: "easeOut" }}
+          >
+            <header className="flex items-center justify-between px-6 pt-10 text-xs uppercase tracking-[0.4em] text-fg/60 md:px-12">
+              <motion.span
+                id="main-navigation-title"
+                initial={{ y: -8, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={{ delay: 0.1, duration: 0.3 }}
+              >
+                Menu
+              </motion.span>
+              <motion.button
+                type="button"
+                onClick={onClose}
+                className="flex items-center gap-2 rounded-full bg-fg/10 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-fg transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                initial={{ y: -8, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={{ delay: 0.15, duration: 0.3 }}
+              >
+                Close
+              </motion.button>
+            </header>
+
+            <div className="flex flex-1 flex-col justify-end gap-16 px-6 pb-12 text-left md:flex-row md:items-end md:justify-between md:px-12 md:pb-16">
+              <nav aria-label="Primary" className="w-full md:w-auto">
+                <motion.ul
+                  className="flex flex-col gap-6 text-4xl font-semibold uppercase tracking-[0.3em] text-fg sm:text-5xl md:text-[clamp(3rem,6vw,4.5rem)]"
+                  initial="hidden"
+                  animate="visible"
+                  variants={{
+                    hidden: {},
+                    visible: {
+                      transition: { staggerChildren: 0.08, delayChildren: 0.15 },
+                    },
+                  }}
+                >
+                  {navigationLinks.map(({ name, href }, index) => (
+                    <motion.li
+                      key={href}
+                      variants={{
+                        hidden: { opacity: 0, y: 24 },
+                        visible: { opacity: 1, y: 0 },
+                      }}
+                    >
+                      <Link
+                        ref={index === 0 ? firstLinkRef : undefined}
+                        href={href}
+                        onClick={onClose}
+                        className="group flex items-center gap-6 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
+                      >
+                        <span className="text-sm font-normal tracking-[0.4em] text-fg/40">0{index + 1}</span>
+                        <span className="relative">
+                          <span className="block transition duration-300 ease-out group-hover:-translate-y-1">{name}</span>
+                          <span className="absolute inset-x-0 bottom-0 h-[3px] origin-left scale-x-0 bg-fg/80 transition-transform duration-300 ease-out group-hover:scale-x-100" />
+                        </span>
+                      </Link>
+                    </motion.li>
+                  ))}
+                </motion.ul>
+              </nav>
+
+              <motion.div
+                className="flex w-full flex-col gap-8 text-sm uppercase tracking-[0.35em] text-fg/60 md:w-64"
+                initial={{ opacity: 0, y: 24 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.35, duration: 0.4 }}
+              >
+                <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
+                  <span>Social</span>
+                  <div className="h-px w-16 bg-fg/20" />
+                </div>
+                <div className="flex flex-wrap gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.35em]">
+                  {socialLinks.map(({ label, href }) => (
+                    <Link
+                      key={label}
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      prefetch={false}
+                      className="rounded-full bg-fg/10 px-5 py-2 transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                    >
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              </motion.div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
-import Link from "next/link";
+import { motion } from "framer-motion";
 import { usePathname } from "next/navigation";
-import dynamic from "next/dynamic";
-import { Suspense, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-const MetaballsCanvas = dynamic(() => import("./three/MetaballsCanvas"), {
-  ssr: false,
-  loading: () => <div className="h-48 w-48 animate-pulse rounded-full bg-fg/10" />,
-});
+import NavOverlay from "./NavOverlay";
 
 const navigationLinks = [
   { name: "home", href: "/" },
@@ -30,6 +25,7 @@ export default function Navbar() {
   const pathname = usePathname();
   const firstLinkRef = useRef<HTMLAnchorElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
   const hasOpenedRef = useRef(false);
 
   useEffect(() => {
@@ -40,6 +36,35 @@ export default function Navbar() {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === "Escape") {
           setIsOpen(false);
+          return;
+        }
+
+        if (event.key === "Tab") {
+          const overlayElement = overlayRef.current;
+          if (!overlayElement) {
+            return;
+          }
+
+          const focusable = overlayElement.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input, select, textarea',
+          );
+
+          if (focusable.length === 0) {
+            return;
+          }
+
+          const firstElement = focusable[0];
+          const lastElement = focusable[focusable.length - 1];
+
+          if (!event.shiftKey && document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+
+          if (event.shiftKey && document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          }
         }
       };
       document.addEventListener("keydown", handleKeyDown);
@@ -100,131 +125,14 @@ export default function Navbar() {
         </span>
       </button>
 
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            id="main-navigation-overlay"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="main-navigation-title"
-            tabIndex={-1}
-            className="fixed inset-0 z-40 overflow-hidden"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.25, ease: "easeInOut" }}
-          >
-            <motion.div
-              className="absolute inset-0 bg-gradient-to-br from-[#05060f] via-[#070b1f]/95 to-[#010106]"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.35, ease: "easeInOut" }}
-            />
-            <div className="pointer-events-none absolute inset-0 opacity-50">
-              <Suspense fallback={null}>
-                <div className="absolute left-1/2 top-1/2 h-[min(70vh,36rem)] w-[min(70vh,36rem)] -translate-x-1/2 -translate-y-1/2">
-                  <MetaballsCanvas />
-                </div>
-              </Suspense>
-            </div>
-
-            <motion.div
-              className="relative z-10 flex h-full w-full flex-col"
-              initial={{ opacity: 0, y: 24 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 24 }}
-              transition={{ duration: 0.35, ease: "easeOut" }}
-            >
-              <header className="flex items-center justify-between px-6 pt-10 text-xs uppercase tracking-[0.4em] text-fg/60 md:px-12">
-                <motion.span
-                  id="main-navigation-title"
-                  initial={{ y: -8, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  transition={{ delay: 0.1, duration: 0.3 }}
-                >
-                  Menu
-                </motion.span>
-                <motion.button
-                  type="button"
-                  onClick={() => setIsOpen(false)}
-                  className="flex items-center gap-2 rounded-full bg-fg/10 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-fg transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-                  initial={{ y: -8, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  transition={{ delay: 0.15, duration: 0.3 }}
-                >
-                  Close
-                </motion.button>
-              </header>
-
-              <div className="flex flex-1 flex-col justify-end gap-16 px-6 pb-12 text-left md:flex-row md:items-end md:justify-between md:px-12 md:pb-16">
-                <nav aria-label="Primary" className="w-full md:w-auto">
-                  <motion.ul
-                    className="flex flex-col gap-6 text-4xl font-semibold uppercase tracking-[0.3em] text-fg sm:text-5xl md:text-[clamp(3rem,6vw,4.5rem)]"
-                    initial="hidden"
-                    animate="visible"
-                    variants={{
-                      hidden: {},
-                      visible: {
-                        transition: { staggerChildren: 0.08, delayChildren: 0.15 },
-                      },
-                    }}
-                  >
-                    {navigationLinks.map(({ name, href }, index) => (
-                      <motion.li
-                        key={href}
-                        variants={{
-                          hidden: { opacity: 0, y: 24 },
-                          visible: { opacity: 1, y: 0 },
-                        }}
-                      >
-                        <Link
-                          ref={index === 0 ? firstLinkRef : undefined}
-                          href={href}
-                          onClick={() => setIsOpen(false)}
-                          className="group flex items-center gap-6 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
-                        >
-                          <span className="text-sm font-normal tracking-[0.4em] text-fg/40">0{index + 1}</span>
-                          <span className="relative">
-                            <span className="block transition duration-300 ease-out group-hover:-translate-y-1">{name}</span>
-                            <span className="absolute inset-x-0 bottom-0 h-[3px] origin-left scale-x-0 bg-fg/80 transition-transform duration-300 ease-out group-hover:scale-x-100" />
-                          </span>
-                        </Link>
-                      </motion.li>
-                    ))}
-                  </motion.ul>
-                </nav>
-
-                <motion.div
-                  className="flex w-full flex-col gap-8 text-sm uppercase tracking-[0.35em] text-fg/60 md:w-64"
-                  initial={{ opacity: 0, y: 24 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.35, duration: 0.4 }}
-                >
-                  <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
-                    <span>Social</span>
-                    <div className="h-px w-16 bg-fg/20" />
-                  </div>
-                  <div className="flex flex-wrap gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.35em]">
-                    {socialLinks.map(({ label, href }) => (
-                      <Link
-                        key={label}
-                        href={href}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        prefetch={false}
-                        className="rounded-full bg-fg/10 px-5 py-2 transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-                      >
-                        {label}
-                      </Link>
-                    ))}
-                  </div>
-                </motion.div>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <NavOverlay
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        firstLinkRef={firstLinkRef}
+        navigationLinks={navigationLinks}
+        socialLinks={socialLinks}
+        overlayRef={overlayRef}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- extract the animated navigation overlay into a dedicated component that dynamically loads the organic shape
- replace the metaballs canvas with a subtle, brand-tinted organic shape and refreshed gradient styling
- retain accessibility by wiring the navbar to the new overlay and adding focus trapping for keyboard users

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d9e586292c832f905e22cc208e1f64