### PR TITLE
Externalize i18n resources into locale JSON files

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -18,7 +18,7 @@ const AvatarOrb = dynamic(() => import("../../components/three/AvatarOrb"), {
 });
 
 export default function AboutPage() {
-  const { t } = useTranslation();
+  const { t } = useTranslation("common");
 
   return (
     <>
@@ -56,6 +56,7 @@ export default function AboutPage() {
               <p>
                 <Trans
                   i18nKey="about.paragraphs.third"
+                  ns="common"
                   components={{
                     github: (
                       <Link

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,7 +12,7 @@ const Experience = dynamic(
 );
 
 export default function ContactPage() {
-  const { t } = useTranslation();
+  const { t } = useTranslation("common");
   const [status, setStatus] = useState<"idle" | "submitted">("idle");
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -1,148 +1,17 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
+import enCommon from "@/public/locales/en/common.json";
+import ptCommon from "@/public/locales/pt/common.json";
+
+export const defaultNS = "common" as const;
+
 const resources = {
   pt: {
-    translation: {
-      home: {
-        hero: {
-          kicker: "PORTFÓLIO DIGITAL DE DUARTOIS",
-          title: "Identidades cinéticas para marcas visionárias.",
-          subtitle:
-            "Crio narrativas digitais que unem arte generativa, movimento e som para lançar experiências inesquecíveis.",
-          ctaProjects: "ver meus projetos",
-          ctaAbout: "mais sobre mim",
-        },
-      },
-      work: {
-        title: "Projetos selecionados",
-        subtitle:
-          "Passe o cursor ou use o teclado sobre cada projeto para explorar um preview do processo criativo.",
-        previewHint: "Preview dinâmico",
-        projects: {
-          aurora: {
-            title: "Aurora Chromatica",
-            year: "2024",
-            description:
-              "Experiência interativa que responde a trilhas sonoras em tempo real, gerando paisagens luminosas para um festival imersivo.",
-            previewAlt: "Visualização abstrata do projeto Aurora Chromatica.",
-          },
-          mare: {
-            title: "Maré Atlântica",
-            year: "2023",
-            description:
-              "Narrativa audiovisual que combina dados de marés e poesia para uma instalação em grande escala no litoral português.",
-            previewAlt: "Poster conceitual do projeto Maré Atlântica.",
-          },
-          spectrum: {
-            title: "Spectrum Pulse",
-            year: "2022",
-            description:
-              "Sistema de identidade modular para uma plataforma de música generativa, com diretrizes responsivas para print e motion.",
-            previewAlt: "Interface dinâmica do projeto Spectrum Pulse.",
-          },
-        },
-      },
-      about: {
-        kicker: "quem sou",
-        title: "Criativo multidisciplinar com foco em futuros visuais.",
-        paragraphs: {
-          first:
-            "Sou Duarte, designer e diretor criativo com raízes em Lisboa e atuação global. Transformo conceitos em experiências digitais unindo JavaScript, React e Three.js à direção de arte cinematográfica.",
-          second:
-            "No estúdio aplico processos ágeis: prototipagem com Tailwind, integrações Stripe, desenho de APIs e modelagem de dados em MongoDB para escalar produtos expressivos.",
-          third:
-            "Entre colaborações sigo estudando som, motion e design generativo — explore meu <github>GitHub</github> (@Duartois) para ver protótipos vivos e ferramentas abertas.",
-        },
-        visualCaption: "Avatar orgânico animado representando Duarte.",
-      },
-      contact: {
-        title: "Vamos criar algo juntos?",
-        subtitle:
-          "Envie uma mensagem com o que você está planejando ou conecte-se pelas redes abaixo.",
-        form: {
-          nameLabel: "Nome",
-          namePlaceholder: "Ana Silva",
-          emailLabel: "E-mail",
-          emailPlaceholder: "voce@estudio.com",
-          messageLabel: "Mensagem",
-          messagePlaceholder: "Conte-me sobre o projeto, prazos e objetivos.",
-          submit: "enviar mensagem",
-          success: "Mensagem enviada! Vou responder em breve.",
-        },
-      },
-    },
+    [defaultNS]: ptCommon,
   },
   en: {
-    translation: {
-      home: {
-        hero: {
-          kicker: "DUARTOIS DIGITAL PORTFOLIO",
-          title: "Kinetic identities for vision-led brands.",
-          subtitle:
-            "I craft digital narratives that blend generative art, motion, and sound to launch unforgettable experiences.",
-          ctaProjects: "see my projects",
-          ctaAbout: "more about me",
-        },
-      },
-      work: {
-        title: "Selected projects",
-        subtitle:
-          "Hover or focus each project to explore a glimpse of the creative process.",
-        previewHint: "Dynamic preview",
-        projects: {
-          aurora: {
-            title: "Aurora Chromatica",
-            year: "2024",
-            description:
-              "Interactive experience reacting to live soundtracks, generating luminous landscapes for an immersive festival.",
-            previewAlt: "Abstract visualization of the Aurora Chromatica project.",
-          },
-          mare: {
-            title: "Atlantic Tide",
-            year: "2023",
-            description:
-              "Audiovisual narrative blending tide data and poetry for a large-scale installation on the Portuguese coast.",
-            previewAlt: "Concept poster for the Atlantic Tide project.",
-          },
-          spectrum: {
-            title: "Spectrum Pulse",
-            year: "2022",
-            description:
-              "Modular identity system for a generative music platform, with responsive guidelines for print and motion.",
-            previewAlt: "Dynamic interface of the Spectrum Pulse project.",
-          },
-        },
-      },
-      about: {
-        kicker: "about me",
-        title: "Multidisciplinary creative focused on visual futures.",
-        paragraphs: {
-          first:
-            "I'm Duarte, a designer and creative director from Lisbon with a global practice. I turn concepts into digital experiences by pairing JavaScript, React, and Three.js with cinematic art direction.",
-          second:
-            "Inside the studio I lean on agile workflows — rapid prototyping with Tailwind, Stripe integrations, API design, and MongoDB data modelling to ship expressive products.",
-          third:
-            "When I'm not co-creating with teams, I'm studying sound, motion, and generative design — browse my <github>GitHub</github> (@Duartois) to see living prototypes and open tools.",
-        },
-        visualCaption: "Animated organic avatar representing Duarte.",
-      },
-      contact: {
-        title: "Shall we create something together?",
-        subtitle:
-          "Send a note with what you're planning or connect through the networks below.",
-        form: {
-          nameLabel: "Name",
-          namePlaceholder: "Alex Johnson",
-          emailLabel: "Email",
-          emailPlaceholder: "you@studio.com",
-          messageLabel: "Message",
-          messagePlaceholder: "Tell me about the project, timeline, and goals.",
-          submit: "send message",
-          success: "Message sent! I'll reply soon.",
-        },
-      },
-    },
+    [defaultNS]: enCommon,
   },
 } as const;
 
@@ -152,10 +21,11 @@ if (!i18n.isInitialized) {
     lng: "pt",
     fallbackLng: "en",
     interpolation: { escapeValue: false },
-    supportedLngs: ["pt", "en"],
-    defaultNS: "translation",
+    supportedLngs: Object.keys(resources),
+    defaultNS,
+    ns: [defaultNS],
   });
 }
 
 export default i18n;
-export type AppTranslationKeys = keyof typeof resources.pt.translation;
+export type AppTranslation = typeof ptCommon;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ const OrganicShape = dynamic(
 );
 
 export default function HomePage() {
-  const { t } = useTranslation();
+  const { t } = useTranslation("common");
 
   return (
     <>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -48,7 +48,7 @@ const projectPreviews: ProjectPreview[] = [
 ];
 
 export default function WorkPage() {
-  const { t } = useTranslation();
+  const { t } = useTranslation("common");
   const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
   const shouldReduceMotion = useReducedMotion();
 

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -10,7 +10,7 @@ const LANGUAGES = [
 ] as const;
 
 export default function LanguageSwitcher() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation("common");
   const currentLanguage = (i18n.resolvedLanguage || i18n.language || "pt").split("-")[0];
 
   return (
@@ -33,7 +33,7 @@ export default function LanguageSwitcher() {
                 : "text-fg/70 hover:text-fg"
             )}
             aria-pressed={isActive}
-            aria-label={`Alterar idioma para ${label}`}
+            aria-label={t("languageSwitcher.ariaLabel", { label })}
           >
             {label}
           </button>

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { Suspense, type RefObject } from "react";
+import { useTranslation } from "react-i18next";
+import "@/app/i18n/config";
 
 const OrganicShape = dynamic(() => import("./three/OrganicShape"), {
   ssr: false,
@@ -39,6 +41,8 @@ export default function NavOverlay({
   socialLinks,
   overlayRef,
 }: NavOverlayProps) {
+  const { t } = useTranslation("common");
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -84,7 +88,7 @@ export default function NavOverlay({
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: 0.1, duration: 0.3 }}
               >
-                Menu
+                {t("navbar.menu")}
               </motion.span>
               <motion.button
                 type="button"
@@ -94,12 +98,12 @@ export default function NavOverlay({
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: 0.15, duration: 0.3 }}
               >
-                Close
+                {t("navbar.closeMenu")}
               </motion.button>
             </header>
 
             <div className="flex flex-1 flex-col justify-end gap-16 px-6 pb-12 text-left md:flex-row md:items-end md:justify-between md:px-12 md:pb-16">
-              <nav aria-label="Primary" className="w-full md:w-auto">
+              <nav aria-label={t("navbar.menu")} className="w-full md:w-auto">
                 <motion.ul
                   className="flex flex-col gap-6 text-4xl font-semibold uppercase tracking-[0.3em] text-fg sm:text-5xl md:text-[clamp(3rem,6vw,4.5rem)]"
                   initial="hidden"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,6 +3,8 @@
 import { motion } from "framer-motion";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import "@/app/i18n/config";
 
 import NavOverlay from "./NavOverlay";
 
@@ -27,6 +29,7 @@ export default function Navbar() {
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const hasOpenedRef = useRef(false);
+  const { t } = useTranslation("common");
 
   useEffect(() => {
     if (isOpen) {
@@ -101,7 +104,7 @@ export default function Navbar() {
         aria-controls="main-navigation-overlay"
         className="group fixed right-6 top-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-fg/20 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition hover:border-fg/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
       >
-        <span className="sr-only">{isOpen ? "Fechar navegação" : "Abrir navegação"}</span>
+        <span className="sr-only">{isOpen ? t("navbar.close") : t("navbar.open")}</span>
         <span aria-hidden="true" className="grid grid-cols-3 gap-1.5">
           {Array.from({ length: 9 }).map((_, index) => (
             <motion.span

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,69 @@
+{
+  "languageSwitcher": {
+    "ariaLabel": "Switch language to {{label}}"
+  },
+  "navbar": {
+    "open": "Open navigation",
+    "close": "Close navigation",
+    "menu": "Menu",
+    "closeMenu": "Close"
+  },
+  "home": {
+    "hero": {
+      "kicker": "DUARTOIS IMMERSIVE PORTFOLIO",
+      "title": "Kinetic identities for brands embracing the future.",
+      "subtitle": "Digital experiences that fuse generative art, spatial sound, and interactive storytelling to spark new sensations.",
+      "ctaProjects": "explore projects",
+      "ctaAbout": "meet the story"
+    }
+  },
+  "work": {
+    "title": "Selected experiments",
+    "subtitle": "Hover or focus to reveal snapshots of the hybrid process between 3D, code, and art direction.",
+    "previewHint": "Pick a project",
+    "projects": {
+      "aurora": {
+        "title": "Aurora Chromatica",
+        "year": "2024",
+        "description": "Responsive installation translating live soundtracks into luminous landscapes for an immersive festival.",
+        "previewAlt": "Abstract visualization of the Aurora Chromatica project."
+      },
+      "mare": {
+        "title": "Atlantic Tide",
+        "year": "2023",
+        "description": "Audiovisual narrative merging tide data, poetry, and projection mapping along the Portuguese coastline.",
+        "previewAlt": "Concept poster for the Atlantic Tide project."
+      },
+      "spectrum": {
+        "title": "Spectrum Pulse",
+        "year": "2022",
+        "description": "Modular identity for a generative music platform with dynamic motion and print guidelines.",
+        "previewAlt": "Dynamic interface of the Spectrum Pulse project."
+      }
+    }
+  },
+  "about": {
+    "kicker": "the mind behind",
+    "title": "Designer-director weaving technology, art, and performance.",
+    "paragraphs": {
+      "first": "I'm Duarte, a Lisbon-born designer and creative director. I pair JavaScript, React, and Three.js with cinematic art direction to turn ideas into multisensory digital experiences.",
+      "second": "Within each engagement I mix rapid prototyping with Tailwind, Stripe integrations, API design, and MongoDB modelling to scale expressive products.",
+      "third": "Between collaborations I research sound, motion, and generative design — explore my <github>GitHub</github> (@Duartois) to find living prototypes and open tools."
+    },
+    "visualCaption": "Animated organic avatar representing Duarte."
+  },
+  "contact": {
+    "title": "Shall we create something together?",
+    "subtitle": "Send a note with what you're planning or connect through the networks below.",
+    "form": {
+      "nameLabel": "Name",
+      "namePlaceholder": "Alex Johnson",
+      "emailLabel": "Email",
+      "emailPlaceholder": "you@studio.com",
+      "messageLabel": "Message",
+      "messagePlaceholder": "Tell me about the project, timeline, and goals.",
+      "submit": "send message",
+      "success": "Message sent! I'll reply soon."
+    }
+  }
+}

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,0 +1,69 @@
+{
+  "languageSwitcher": {
+    "ariaLabel": "Alterar idioma para {{label}}"
+  },
+  "navbar": {
+    "open": "Abrir navegação",
+    "close": "Fechar navegação",
+    "menu": "Menu",
+    "closeMenu": "Fechar"
+  },
+  "home": {
+    "hero": {
+      "kicker": "PORTFÓLIO IMERSIVO DE DUARTOIS",
+      "title": "Identidades cinéticas para marcas que abraçam o futuro.",
+      "subtitle": "Experiências digitais que misturam arte generativa, som espacial e narrativas interativas para despertar novos sentidos.",
+      "ctaProjects": "explorar projetos",
+      "ctaAbout": "conhecer trajetória"
+    }
+  },
+  "work": {
+    "title": "Experimentos selecionados",
+    "subtitle": "Passe o cursor ou use o teclado para revelar snapshots do processo híbrido entre 3D, código e direção de arte.",
+    "previewHint": "Escolha um projeto",
+    "projects": {
+      "aurora": {
+        "title": "Aurora Chromatica",
+        "year": "2024",
+        "description": "Instalação responsiva que traduz trilhas sonoras em paisagens luminosas ao vivo para um festival imersivo.",
+        "previewAlt": "Visualização abstrata do projeto Aurora Chromatica."
+      },
+      "mare": {
+        "title": "Maré Atlântica",
+        "year": "2023",
+        "description": "Narrativa audiovisual que combina dados de marés, poesia e projeções para ocupar a costa portuguesa.",
+        "previewAlt": "Poster conceitual do projeto Maré Atlântica."
+      },
+      "spectrum": {
+        "title": "Spectrum Pulse",
+        "year": "2022",
+        "description": "Identidade modular para uma plataforma de música generativa com diretrizes dinâmicas para motion e print.",
+        "previewAlt": "Interface dinâmica do projeto Spectrum Pulse."
+      }
+    }
+  },
+  "about": {
+    "kicker": "quem assina",
+    "title": "Designer-diretor que costura tecnologia, arte e performance.",
+    "paragraphs": {
+      "first": "Sou Duarte, designer e diretor criativo nascido em Lisboa. Conecto JavaScript, React e Three.js à direção de arte cinematográfica para transformar ideias em experiências digitais multisensoriais.",
+      "second": "Nos projetos, combino protótipos rápidos com Tailwind, integrações Stripe, design de APIs e modelagem em MongoDB para escalar produtos expressivos.",
+      "third": "Entre colaborações, investigo som, motion e design generativo — explore meu <github>GitHub</github> (@Duartois) para ver protótipos vivos e ferramentas abertas."
+    },
+    "visualCaption": "Avatar orgânico animado representando Duarte."
+  },
+  "contact": {
+    "title": "Vamos criar algo juntos?",
+    "subtitle": "Envie uma mensagem com o que você está planejando ou conecte-se pelas redes abaixo.",
+    "form": {
+      "nameLabel": "Nome",
+      "namePlaceholder": "Ana Silva",
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "voce@estudio.com",
+      "messageLabel": "Mensagem",
+      "messagePlaceholder": "Conte-me sobre o projeto, prazos e objetivos.",
+      "submit": "enviar mensagem",
+      "success": "Mensagem enviada! Vou responder em breve."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- move translation content into public locale JSON files with refreshed English and Portuguese copy
- load the new JSON resources in the i18next configuration and set the common namespace as default
- update pages and shared components to pull strings from the common namespace, including navigation controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e7089fb8832f8fd27734ead2344e