### PR TITLE
Refine three.js variants across marketing pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,12 +4,10 @@ import dynamic from "next/dynamic";
 import Navbar from "../../components/Navbar";
 import { Trans, useTranslation } from "react-i18next";
 import Link from "next/link";
-import { Suspense } from "react";
-import { Canvas } from "@react-three/fiber";
 import "../i18n/config";
 
-const OrganicShape = dynamic(
-  () => import("../../components/three/OrganicShape"),
+const Experience = dynamic(
+  () => import("../../components/three/Experience"),
   { ssr: false },
 );
 
@@ -24,21 +22,10 @@ export default function AboutPage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10">
-          <Canvas
-            camera={{ position: [0, 0, 6], fov: 42 }}
-            gl={{ antialias: true, alpha: true }}
-            dpr={[1, 2]}
-            className="h-full w-full"
-          >
-            <ambientLight intensity={0.5} />
-            <directionalLight position={[5, 6, 8]} intensity={1.2} />
-            <Suspense fallback={null}>
-              <OrganicShape variant="torusKnot" colorScheme="lagoon" />
-            </Suspense>
-          </Canvas>
+        <div className="absolute inset-0 -z-10">
+          <Experience variant="about" className="pointer-events-auto" />
           <div
-            className="absolute inset-0 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg"
             aria-hidden
           />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,12 @@
 
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { Suspense } from "react";
-import { Canvas } from "@react-three/fiber";
 import Navbar from "../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
-const OrganicShape = dynamic(
-  () => import("../components/three/OrganicShape"),
+const Experience = dynamic(
+  () => import("../components/three/Experience"),
   {
     ssr: false,
   },
@@ -22,21 +20,10 @@ export default function HomePage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10">
-          <Canvas
-            camera={{ position: [0, 0, 6], fov: 42 }}
-            gl={{ antialias: true, alpha: true }}
-            dpr={[1, 2]}
-            className="h-full w-full"
-          >
-            <ambientLight intensity={0.5} />
-            <directionalLight position={[5, 6, 8]} intensity={1.2} />
-            <Suspense fallback={null}>
-              <OrganicShape variant="hero" colorScheme="brand" />
-            </Suspense>
-          </Canvas>
+        <div className="absolute inset-0 -z-10">
+          <Experience variant="home" className="pointer-events-auto" />
           <div
-            className="absolute inset-0 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg"
             aria-hidden
           />
         </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -7,14 +7,15 @@ import { Canvas } from "@react-three/fiber";
 import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
+import { variantMapping, type VariantName } from "../../store/variants";
 
 const Experience = dynamic(
   () => import("../../components/three/Experience"),
   { ssr: false }
 );
 
-const OrganicShape = dynamic(
-  () => import("../../components/three/OrganicShape"),
+const ProceduralShapes = dynamic(
+  () => import("../../components/three/ProceduralShapes"),
   { ssr: false },
 );
 
@@ -22,28 +23,52 @@ const projectOrder = ["aurora", "mare", "spectrum"] as const;
 
 type ProjectKey = (typeof projectOrder)[number];
 
+type ShapePalette = { colorA: string; colorB: string }[];
+
 type ProjectPreview = {
   id: ProjectKey;
-  shape: {
-    variant: "marchingCubes" | "torusKnot";
-    colorScheme: "aurora" | "blossom" | "lagoon" | "brand";
-  };
+  variantName: VariantName;
+  palette: ShapePalette;
   showDescription?: boolean;
+};
+
+const previewPalettes: Record<ProjectKey, ShapePalette> = {
+  aurora: [
+    { colorA: "#C7D2FE", colorB: "#4F46E5" },
+    { colorA: "#BFDBFE", colorB: "#2563EB" },
+    { colorA: "#FDE68A", colorB: "#F97316" },
+    { colorA: "#F9A8D4", colorB: "#EC4899" },
+  ],
+  mare: [
+    { colorA: "#BBF7D0", colorB: "#10B981" },
+    { colorA: "#BAE6FD", colorB: "#0284C7" },
+    { colorA: "#DDD6FE", colorB: "#7C3AED" },
+    { colorA: "#99F6E4", colorB: "#14B8A6" },
+  ],
+  spectrum: [
+    { colorA: "#FDE68A", colorB: "#FACC15" },
+    { colorA: "#FBCFE8", colorB: "#EC4899" },
+    { colorA: "#BAE6FD", colorB: "#3B82F6" },
+    { colorA: "#C7D2FE", colorB: "#6366F1" },
+  ],
 };
 
 const projectPreviews: ProjectPreview[] = [
   {
     id: "aurora",
-    shape: { variant: "marchingCubes", colorScheme: "aurora" },
+    variantName: "home",
+    palette: previewPalettes.aurora,
   },
   {
     id: "mare",
-    shape: { variant: "torusKnot", colorScheme: "lagoon" },
+    variantName: "about",
+    palette: previewPalettes.mare,
     showDescription: true,
   },
   {
     id: "spectrum",
-    shape: { variant: "marchingCubes", colorScheme: "blossom" },
+    variantName: "work",
+    palette: previewPalettes.spectrum,
   },
 ];
 
@@ -52,16 +77,18 @@ export default function WorkPage() {
   const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
   const shouldReduceMotion = useReducedMotion();
 
-  const activePreview = projectPreviews.find((preview) => preview.id === activeProject)!;
+  const activePreview = projectPreviews.find(
+    (preview) => preview.id === activeProject,
+  )!;
 
   return (
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10">
-          <Experience variant="work" />
+        <div className="absolute inset-0 -z-10">
+          <Experience variant="work" className="pointer-events-auto" />
           <div
-            className="absolute inset-0 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg"
             aria-hidden
           />
         </div>
@@ -133,9 +160,10 @@ export default function WorkPage() {
                     <ambientLight intensity={0.5} />
                     <directionalLight position={[5, 6, 8]} intensity={1.2} />
                     <Suspense fallback={null}>
-                      <OrganicShape
-                        variant={activePreview.shape.variant}
-                        colorScheme={activePreview.shape.colorScheme}
+                      <ProceduralShapes
+                        variantOverride={variantMapping[activePreview.variantName]}
+                        palette={activePreview.palette}
+                        parallax={false}
                       />
                     </Suspense>
                   </Canvas>

--- a/components/three/Experience.tsx
+++ b/components/three/Experience.tsx
@@ -4,7 +4,7 @@ import { Canvas } from "@react-three/fiber";
 import { Suspense, useEffect } from "react";
 import { Html } from "@react-three/drei";
 import Shapes from "./ProceduralShapes";
-import { useVariantStore } from "../../store/variants";
+import { useVariantStore, type VariantName } from "../../store/variants";
 
 interface ExperienceProps {
   /**
@@ -13,10 +13,15 @@ interface ExperienceProps {
    * repositions the shapes to spell out a different arrangement or
    * create a different composition.  See `store/variants.ts`.
    */
-  variant: "home" | "about" | "work" | "contact";
+  variant: VariantName;
+  /**
+   * Optional class name applied to the wrapper so the canvas can be
+   * positioned relative to different layouts.
+   */
+  className?: string;
 }
 
-export default function Experience({ variant }: ExperienceProps) {
+export default function Experience({ variant, className }: ExperienceProps) {
   const setVariant = useVariantStore((state) => state.setVariant);
 
   // Whenever the variant prop changes, update the global store so that
@@ -26,12 +31,17 @@ export default function Experience({ variant }: ExperienceProps) {
     setVariant(variant);
   }, [variant, setVariant]);
 
+  const containerClassName = className
+    ? `${className} h-full w-full`
+    : "h-full w-full";
+
   return (
-    <div className="h-screen w-screen">
+    <div className={containerClassName}>
       <Canvas
         camera={{ position: [0, 0, 6], fov: 40 }}
-        gl={{ antialias: true, alpha: false }}
+        gl={{ antialias: true, alpha: true }}
         dpr={[1, 2]}
+        className="h-full w-full"
       >
         {/* Ambient and directional lighting to softly illuminate the shapes */}
         <ambientLight intensity={0.5} />

--- a/components/three/ProceduralShapes.tsx
+++ b/components/three/ProceduralShapes.tsx
@@ -4,15 +4,41 @@ import * as THREE from "three";
 import React, { useMemo, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { a, useSpring } from "@react-spring/three";
-import { useVariantStore } from "../../store/variants";
+import {
+  useVariantStore,
+  type VariantState,
+} from "../../store/variants";
 import GradientMat from "../../materials/GradientMat";
 
 // Tupla util p/ react-spring aceitar vetores
 const tuple = (v: [number, number, number]) => v as unknown as THREE.Vector3Tuple;
 
-export default function ProceduralShapes() {
+type ProceduralShapesProps = {
+  /**
+   * Overrides the global variant store and renders the provided transforms.
+   * Useful for small previews that should not mutate the global scene.
+   */
+  variantOverride?: VariantState;
+  /**
+   * Custom colours for each mesh.  Pass four pairs for the two torus segments,
+   * the spline and the dot respectively.
+   */
+  palette?: { colorA: string; colorB: string }[];
+  /**
+   * Enables pointer based parallax.  Disable for static previews in tight
+   * containers.
+   */
+  parallax?: boolean;
+};
+
+export default function ProceduralShapes({
+  variantOverride,
+  palette,
+  parallax = true,
+}: ProceduralShapesProps) {
   // Lê as variantes já usadas pelas suas páginas (home/work/about)
-  const variant = useVariantStore((s) => s.variant);
+  const storeVariant = useVariantStore((s) => s.variant);
+  const variant = variantOverride ?? storeVariant;
 
   // === Geometrias (primitives — como no Sharlee) ===
   // Dois “C” (torus parciais), um “S” (tube em spline), e um “dot” (esfera).
@@ -91,8 +117,8 @@ export default function ProceduralShapes() {
     const t = clock.getElapsedTime();
 
     // Parallax/tilt suave, reduzido em mobile
-    const px = pointer.x * (isMobile ? 0.02 : 0.045);
-    const py = pointer.y * (isMobile ? 0.015 : 0.035);
+    const px = parallax ? pointer.x * (isMobile ? 0.02 : 0.045) : 0;
+    const py = parallax ? pointer.y * (isMobile ? 0.015 : 0.035) : 0;
 
     // “Respiração” sutil
     const breathe = (isMobile ? 0.006 : 0.01) * Math.sin(t * 0.8);
@@ -120,13 +146,14 @@ export default function ProceduralShapes() {
   // === Paleta pastel (fixa por shape) — igual vibe do site de referência ===
   // Usa seu GradientMat para fresnel/iridescência e evita mexer em Tailwind aqui.
   const mats = useMemo(
-    () => [
-      { a: "#9CA3AF", b: "#6366F1" }, // C top: cinza→índigo
-      { a: "#60A5FA", b: "#4338CA" }, // C bottom: azul→índigo
-      { a: "#F472B6", b: "#EC4899" }, // S: rosa→pink
-      { a: "#34D399", b: "#10B981" }, // dot: verde
-    ],
-    []
+    () =>
+      palette ?? [
+        { colorA: "#9CA3AF", colorB: "#6366F1" }, // C top: cinza→índigo
+        { colorA: "#60A5FA", colorB: "#4338CA" }, // C bottom: azul→índigo
+        { colorA: "#F472B6", colorB: "#EC4899" }, // S: rosa→pink
+        { colorA: "#34D399", colorB: "#10B981" }, // dot: verde
+      ],
+    [palette]
   );
 
   return (
@@ -139,7 +166,11 @@ export default function ProceduralShapes() {
         rotation-y={cTop.rotationY}
         rotation-z={cTop.rotationZ}
       >
-        <GradientMat colorA={mats[0].a} colorB={mats[0].b} fresnelStrength={1.2} />
+        <GradientMat
+          colorA={mats[0].colorA}
+          colorB={mats[0].colorB}
+          fresnelStrength={1.2}
+        />
       </a.mesh>
 
       {/* C de baixo */}
@@ -150,7 +181,11 @@ export default function ProceduralShapes() {
         rotation-y={cBottom.rotationY}
         rotation-z={cBottom.rotationZ}
       >
-        <GradientMat colorA={mats[1].a} colorB={mats[1].b} fresnelStrength={1.2} />
+        <GradientMat
+          colorA={mats[1].colorA}
+          colorB={mats[1].colorB}
+          fresnelStrength={1.2}
+        />
       </a.mesh>
 
       {/* “S” (tube) */}
@@ -161,7 +196,11 @@ export default function ProceduralShapes() {
         rotation-y={sShape.rotationY}
         rotation-z={sShape.rotationZ}
       >
-        <GradientMat colorA={mats[2].a} colorB={mats[2].b} fresnelStrength={1.2} />
+        <GradientMat
+          colorA={mats[2].colorA}
+          colorB={mats[2].colorB}
+          fresnelStrength={1.2}
+        />
       </a.mesh>
 
       {/* Ponto (dot) */}
@@ -172,7 +211,11 @@ export default function ProceduralShapes() {
         rotation-y={dot.rotationY}
         rotation-z={dot.rotationZ}
       >
-        <GradientMat colorA={mats[3].a} colorB={mats[3].b} fresnelStrength={1.2} />
+        <GradientMat
+          colorA={mats[3].colorA}
+          colorB={mats[3].colorB}
+          fresnelStrength={1.2}
+        />
       </a.mesh>
     </group>
   );

--- a/store/variants.ts
+++ b/store/variants.ts
@@ -1,4 +1,6 @@
-import { create } from 'zustand';
+import { create } from "zustand";
+
+export type VariantName = "home" | "about" | "work" | "contact";
 
 export type ShapeTransform = {
   position: [number, number, number];
@@ -13,92 +15,89 @@ export type VariantState = {
   dot: ShapeTransform;
 };
 
-export const variantMapping: Record<'home' | 'about' | 'work' | 'contact', VariantState> = {
+export const variantMapping: Record<VariantName, VariantState> = {
   home: {
     cTop: {
-      position: [-1.5, 1.2, 0],
-      rotation: [0, 0, Math.PI / 2],
+      position: [-1.8, 1.35, 0.1],
+      rotation: [0.32, -0.1, 1.28],
     },
     cBottom: {
-      position: [-1.5, -1.2, 0],
-      rotation: [0, 0, -Math.PI / 2],
+      position: [-1.6, -1.25, -0.05],
+      rotation: [-0.36, 0.12, -1.22],
     },
     sShape: {
-      position: [0, 0, 0],
-      rotation: [0, 0, 0],
+      position: [0.6, 0.25, 0],
+      rotation: [0.1, 0.35, -0.28],
     },
     dot: {
-      position: [2.4, 0, 0],
-      rotation: [0, 0, 0],
+      position: [2.35, -0.2, 0.08],
+      rotation: [0.22, -0.12, 0.58],
     },
   },
   about: {
-    // Spread the shapes evenly on a circle
     cTop: {
-      position: [0, 2.0, 0],
-      rotation: [0, 0, Math.PI],
+      position: [1.5, 1.65, 0.18],
+      rotation: [0.28, 0.06, 2.35],
     },
     cBottom: {
-      position: [0, -2.0, 0],
-      rotation: [0, 0, 0],
+      position: [-1.75, -1.4, -0.12],
+      rotation: [-0.34, -0.1, -2.18],
     },
     sShape: {
-      position: [-2.0, 0, 0],
-      rotation: [0, 0, -Math.PI / 4],
+      position: [-2.15, 0.75, 0.04],
+      rotation: [0.12, 0.28, 0.95],
     },
     dot: {
-      position: [2.0, 0, 0],
-      rotation: [0, 0, 0],
+      position: [1.9, -1.85, 0.12],
+      rotation: [0.18, 0.16, 0.38],
     },
   },
   work: {
-    // Compose the shapes into a diagonal composition
     cTop: {
-      position: [-2.0, 1.5, 0],
-      rotation: [0, 0, Math.PI / 3],
+      position: [-2.35, 1.85, 0.16],
+      rotation: [0.36, -0.22, 1.62],
     },
     cBottom: {
-      position: [-1.0, -1.5, 0],
-      rotation: [0, 0, -Math.PI / 6],
+      position: [-0.85, -1.85, -0.08],
+      rotation: [-0.42, 0.18, -1.28],
     },
     sShape: {
-      position: [1.2, 0.5, 0],
-      rotation: [0, 0, Math.PI / 8],
+      position: [1.55, 0.95, 0.02],
+      rotation: [0.22, -0.38, 0.22],
     },
     dot: {
-      position: [2.8, -0.8, 0],
-      rotation: [0, 0, 0],
+      position: [2.95, -0.95, 0.1],
+      rotation: [0.34, 0.14, 0.28],
     },
   },
   contact: {
-    // Stack everything in the centre for the contact page
     cTop: {
-      position: [0, 1.5, 0],
-      rotation: [0, 0, 0],
+      position: [0, 1.55, 0.1],
+      rotation: [0.16, 0.05, 0.08],
     },
     cBottom: {
-      position: [0, -1.5, 0],
-      rotation: [0, 0, 0],
+      position: [0, -1.55, -0.05],
+      rotation: [-0.18, -0.05, -0.12],
     },
     sShape: {
       position: [0, 0, 0],
-      rotation: [0, 0, Math.PI / 2],
+      rotation: [0.18, 0.32, 1.48],
     },
     dot: {
-      position: [0, 0, 0],
-      rotation: [0, 0, 0],
+      position: [0.2, -0.1, 0.04],
+      rotation: [0.1, 0.08, 0.16],
     },
   },
 };
 
 interface VariantStore {
-  variantName: 'home' | 'about' | 'work' | 'contact';
+  variantName: VariantName;
   variant: VariantState;
-  setVariant: (name: 'home' | 'about' | 'work' | 'contact') => void;
+  setVariant: (name: VariantName) => void;
 }
 
 export const useVariantStore = create<VariantStore>((set) => ({
-  variantName: 'home',
+  variantName: "home",
   variant: variantMapping.home,
   setVariant: (name) =>
     set(() => ({ variantName: name, variant: variantMapping[name] })),


### PR DESCRIPTION
## Summary
- replace the bespoke OrganicShape canvases on the home and about pages with the shared Experience scene tied to the variant store
- refactor the work page project preview to reuse ProceduralShapes with palette overrides while keeping the Experience background active
- tune the variant store transforms so the home, about, and work compositions mirror the updated layouts

## Testing
- `npm run dev -- --hostname 0.0.0.0 --port 3000`


------
https://chatgpt.com/codex/tasks/task_e_68da8f77fa80832f89186ae8ec68028e