### PR TITLE
Internationalize loader UI and theme toggle

### DIFF
--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -216,7 +216,7 @@ export default function NavOverlay({
                 transition={{ delay: 0.35, duration: 0.4 }}
               >
                 <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
-                  <span>Social</span>
+                  <span>{t("navOverlay.socialHeading")}</span>
                   <div className="h-px w-16 bg-fg/20" />
                 </div>
                 <div className="flex flex-wrap gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.35em]">

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -3,6 +3,9 @@
 import { Suspense, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import { useProgress } from "@react-three/drei";
+import { useReducedMotion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import "@/app/i18n/config";
 import type { VariantState } from "../store/variants";
 
 const ProceduralPreview = dynamic(() => import("./three/ProceduralCanvas"), {
@@ -44,6 +47,8 @@ export default function Preloader({ onComplete }: PreloaderProps) {
   const { progress, active } = useProgress();
   const hasCompletedRef = useRef(false);
   const formattedProgress = Math.round(progress);
+  const prefersReducedMotion = useReducedMotion();
+  const { t } = useTranslation("common");
 
   useEffect(() => {
     if (!active && !hasCompletedRef.current) {
@@ -58,20 +63,30 @@ export default function Preloader({ onComplete }: PreloaderProps) {
       role="status"
       aria-live="polite"
     >
-      <Suspense fallback={<div className="h-48 w-48 animate-pulse rounded-full bg-fg/10" />}> 
-        <div className="pointer-events-none"> 
-          <ProceduralPreview
-            className="h-48 w-48"
-            variantOverride={PRELOADER_VARIANT}
-            palette={PRELOADER_PALETTE}
-            parallax={false}
-            dpr={[1, 1.5]}
-          />
-        </div>
-      </Suspense>
+      {prefersReducedMotion ? (
+        <div className="h-48 w-48 rounded-full bg-fg/10" aria-hidden />
+      ) : (
+        <Suspense
+          fallback={
+            <div className="h-48 w-48 animate-pulse rounded-full bg-fg/10" aria-hidden />
+          }
+        >
+          <div className="pointer-events-none">
+            <ProceduralPreview
+              className="h-48 w-48"
+              variantOverride={PRELOADER_VARIANT}
+              palette={PRELOADER_PALETTE}
+              parallax={false}
+              dpr={[1, 1.5]}
+            />
+          </div>
+        </Suspense>
+      )}
       <div className="text-center text-fg">
-        <p className="text-lg font-semibold tracking-wide">Materializing shapes…</p>
-        <p className="mt-1 text-sm font-medium text-fg/70">{formattedProgress}%</p>
+        <p className="text-lg font-semibold tracking-wide">{t("preloader.title")}</p>
+        <p className="mt-1 text-sm font-medium text-fg/70" aria-live="polite">
+          {t("preloader.progress", { value: formattedProgress })}
+        </p>
       </div>
     </div>
   );

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,20 +1,30 @@
 "use client";
 
 import { useTheme } from "@/app/theme/ThemeContext";
+import { useTranslation } from "react-i18next";
+import "@/app/i18n/config";
 
 export default function ThemeToggle() {
   const { theme, toggle } = useTheme();
-
-  const nextThemeLabel = theme === "dark" ? "claro" : "escuro";
+  const { t, i18n } = useTranslation("common");
+  const currentThemeKey = theme === "dark" ? "dark" : "light";
+  const nextThemeKey = currentThemeKey === "dark" ? "light" : "dark";
+  const nextThemeLabel = t(`themeToggle.themes.${nextThemeKey}`);
+  const currentThemeLabel = t(`themeToggle.themes.${currentThemeKey}`);
+  const resolvedLanguage = (i18n.resolvedLanguage || i18n.language || "en").split("-")[0];
+  const shouldCapitalizeTitle = resolvedLanguage !== "pt";
+  const titleThemeLabel = shouldCapitalizeTitle
+    ? currentThemeLabel.charAt(0).toUpperCase() + currentThemeLabel.slice(1)
+    : currentThemeLabel;
 
   return (
     <button
       type="button"
       onClick={toggle}
       className="flex h-9 w-9 items-center justify-center rounded-full border border-fg/20 bg-bg/90 text-lg text-fg shadow-soft transition hover:border-fg/40 hover:bg-fg/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg dark:border-fg/30 dark:hover:border-fg/60"
-      aria-label={`Alternar para o tema ${nextThemeLabel}`}
+      aria-label={t("themeToggle.ariaLabel", { theme: nextThemeLabel })}
       aria-pressed={theme === "dark"}
-      title={`Tema ${theme === "dark" ? "escuro" : "claro"}`}
+      title={t("themeToggle.title", { theme: titleThemeLabel })}
     >
       <span aria-hidden>{theme === "dark" ? "🌙" : "☀️"}</span>
     </button>

--- a/components/three/Experience.tsx
+++ b/components/three/Experience.tsx
@@ -3,6 +3,8 @@
 import { Canvas } from "@react-three/fiber";
 import { Suspense, useEffect } from "react";
 import { Html } from "@react-three/drei";
+import { useTranslation } from "react-i18next";
+import "@/app/i18n/config";
 import Shapes from "./ProceduralShapes";
 import { useVariantStore, type VariantName } from "../../store/variants";
 
@@ -23,6 +25,7 @@ interface ExperienceProps {
 
 export default function Experience({ variant, className }: ExperienceProps) {
   const setVariant = useVariantStore((state) => state.setVariant);
+  const { t } = useTranslation("common");
 
   // Whenever the variant prop changes, update the global store so that
   // animations can transition to the new values.  Because this is a
@@ -53,7 +56,7 @@ export default function Experience({ variant, className }: ExperienceProps) {
           fallback={
             <Html center>
               <div className="rounded-full bg-fg/10 px-6 py-3 text-sm font-medium text-fg/70 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)]">
-                Materializing shapes…
+                {t("experience.loadingFallback")}
               </div>
             </Html>
           }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -65,5 +65,23 @@
       "submit": "send message",
       "success": "Message sent! I'll reply soon."
     }
+  },
+  "preloader": {
+    "title": "Materializing shapes…",
+    "progress": "Loading {{value}}%"
+  },
+  "experience": {
+    "loadingFallback": "Materializing shapes…"
+  },
+  "themeToggle": {
+    "ariaLabel": "Switch to the {{theme}} theme",
+    "title": "{{theme}} theme",
+    "themes": {
+      "light": "light",
+      "dark": "dark"
+    }
+  },
+  "navOverlay": {
+    "socialHeading": "Social"
   }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -65,5 +65,23 @@
       "submit": "enviar mensagem",
       "success": "Mensagem enviada! Vou responder em breve."
     }
+  },
+  "preloader": {
+    "title": "Materializando formas…",
+    "progress": "Carregando {{value}}%"
+  },
+  "experience": {
+    "loadingFallback": "Materializando formas…"
+  },
+  "themeToggle": {
+    "ariaLabel": "Alternar para o tema {{theme}}",
+    "title": "Tema {{theme}}",
+    "themes": {
+      "light": "claro",
+      "dark": "escuro"
+    }
+  },
+  "navOverlay": {
+    "socialHeading": "Redes"
   }
 }


### PR DESCRIPTION
## Summary
- add localization keys for loader, 3D fallback, theme toggle, and navigation overlay labels in both locales
- translate the preloader and scene fallback messaging with reduced-motion friendly behavior
- internationalize ThemeToggle accessibility copy using the shared namespace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da97aa48d4832fbe48051a1c5d5b95