### PR TITLE
Refine procedural gradients with theme-aware uniforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ lighting effect, matching the glossy “blob” aesthetic of the original site.
 
 4. **Changing the material**
 
-   The custom shader material lives in `materials/GradientMat.tsx`.  It
-   supports two colour uniforms (`colorA` and `colorB`) and a
-   `fresnelStrength` uniform controlling the intensity of the rim light.
-   Feel free to adjust these values or replace the shader with any
-   other `THREE.Material`.
+  The custom shader material lives in `materials/GradientMat.tsx`.  It
+  exposes four gradient colour uniforms (`uColor1` – `uColor4`) and
+  animated controls (`uTime`, `uAmp`, `uFreq`) that drive the vertex
+  displacement.  Feel free to tweak these values or replace the shader
+  with any other `THREE.Material`.
 
 5. **Extending the project**
 

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -8,6 +8,7 @@ import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 import { variantMapping, type VariantName } from "../../store/variants";
+import type { GradientPalette } from "../../components/three/ProceduralShapes";
 
 const Experience = dynamic(
   () => import("../../components/three/Experience"),
@@ -23,33 +24,31 @@ const projectOrder = ["aurora", "mare", "spectrum"] as const;
 
 type ProjectKey = (typeof projectOrder)[number];
 
-type ShapePalette = { colorA: string; colorB: string }[];
-
 type ProjectPreview = {
   id: ProjectKey;
   variantName: VariantName;
-  palette: ShapePalette;
+  palette: GradientPalette;
   showDescription?: boolean;
 };
 
-const previewPalettes: Record<ProjectKey, ShapePalette> = {
+const previewPalettes: Record<ProjectKey, GradientPalette> = {
   aurora: [
-    { colorA: "#C7D2FE", colorB: "#4F46E5" },
-    { colorA: "#BFDBFE", colorB: "#2563EB" },
-    { colorA: "#FDE68A", colorB: "#F97316" },
-    { colorA: "#F9A8D4", colorB: "#EC4899" },
+    ["#C7D2FE", "#A5B4FF", "#7C8BFF", "#4F46E5"],
+    ["#BFDBFE", "#93C5FD", "#5EA3F4", "#2563EB"],
+    ["#FDE68A", "#FACA61", "#F6A53D", "#F97316"],
+    ["#F9A8D4", "#F472B6", "#F04F9A", "#EC4899"],
   ],
   mare: [
-    { colorA: "#BBF7D0", colorB: "#10B981" },
-    { colorA: "#BAE6FD", colorB: "#0284C7" },
-    { colorA: "#DDD6FE", colorB: "#7C3AED" },
-    { colorA: "#99F6E4", colorB: "#14B8A6" },
+    ["#BBF7D0", "#86EFAC", "#4ADE80", "#10B981"],
+    ["#BAE6FD", "#7DD3FC", "#38BDF8", "#0284C7"],
+    ["#DDD6FE", "#C4B5FD", "#A78BFA", "#7C3AED"],
+    ["#99F6E4", "#5EEAD4", "#2DD4BF", "#14B8A6"],
   ],
   spectrum: [
-    { colorA: "#FDE68A", colorB: "#FACC15" },
-    { colorA: "#FBCFE8", colorB: "#EC4899" },
-    { colorA: "#BAE6FD", colorB: "#3B82F6" },
-    { colorA: "#C7D2FE", colorB: "#6366F1" },
+    ["#FDE68A", "#FCD34D", "#FBBF24", "#FACC15"],
+    ["#FBCFE8", "#F472B6", "#F04F9A", "#EC4899"],
+    ["#BAE6FD", "#7DD3FC", "#38BDF8", "#3B82F6"],
+    ["#C7D2FE", "#A5B4FF", "#818CF8", "#6366F1"],
   ],
 };
 

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -10,6 +10,7 @@ import {
   useVariantStore,
   type VariantName,
 } from "../store/variants";
+import type { GradientPalette } from "./three/ProceduralShapes";
 
 const OrganicShapeFallback = () => (
   <div className="h-full w-full animate-pulse rounded-full bg-accent2-200/20" />
@@ -64,12 +65,12 @@ export default function NavOverlay({
     wasOpenRef.current = isOpen;
   }, [currentVariantName, isOpen, setVariant]);
 
-  const overlayPalette = useMemo(
+  const overlayPalette = useMemo<GradientPalette>(
     () => [
-      { colorA: "#f5eaff", colorB: "#d1b8ff" },
-      { colorA: "#ffe1f1", colorB: "#f57bb8" },
-      { colorA: "#c7fbf3", colorB: "#4dd8cf" },
-      { colorA: "#e9ffd6", colorB: "#9be26a" },
+      ["#f5eaff", "#e4d5ff", "#d4bfff", "#d1b8ff"],
+      ["#ffe1f1", "#ffc9e4", "#ffadd4", "#f57bb8"],
+      ["#c7fbf3", "#9df3e5", "#6fe4d6", "#4dd8cf"],
+      ["#e9ffd6", "#c8f6a0", "#aeee78", "#9be26a"],
     ],
     []
   );

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -7,6 +7,7 @@ import { useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
 import type { VariantState } from "../store/variants";
+import type { GradientPalette } from "./three/ProceduralShapes";
 
 const ProceduralPreview = dynamic(() => import("./three/ProceduralCanvas"), {
   ssr: false,
@@ -32,11 +33,11 @@ const PRELOADER_VARIANT: VariantState = {
   },
 };
 
-const PRELOADER_PALETTE = [
-  { colorA: "#f8f5ff", colorB: "#ceb5ff" },
-  { colorA: "#ffeaf5", colorB: "#ff9fcf" },
-  { colorA: "#dffdf7", colorB: "#65ded1" },
-  { colorA: "#f3ffe3", colorB: "#baf775" },
+const PRELOADER_PALETTE: GradientPalette = [
+  ["#f8f5ff", "#eadfff", "#d9c5ff", "#cbb2ff"],
+  ["#ffeaf5", "#ffd4e8", "#ffb9d8", "#ff9fcf"],
+  ["#dffdf7", "#bdf4ea", "#87e6df", "#65ded1"],
+  ["#f3ffe3", "#d8f8a8", "#c1f27d", "#baf775"],
 ];
 
 interface PreloaderProps {

--- a/components/three/ProceduralCanvas.tsx
+++ b/components/three/ProceduralCanvas.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from "@react-three/fiber";
 import { Suspense, type ReactNode } from "react";
-import ProceduralShapes from "./ProceduralShapes";
+import ProceduralShapes, { type GradientPalette } from "./ProceduralShapes";
 import type { VariantState } from "../../store/variants";
 
 type CanvasCamera = {
@@ -18,7 +18,7 @@ export type ProceduralCanvasProps = {
   dpr?: number | [number, number];
   lights?: ReactNode;
   variantOverride?: VariantState;
-  palette?: { colorA: string; colorB: string }[];
+  palette?: GradientPalette;
   parallax?: boolean;
 };
 

--- a/materials/GradientMat.tsx
+++ b/materials/GradientMat.tsx
@@ -1,77 +1,120 @@
 "use client";
 
-import { shaderMaterial } from '@react-three/drei';
-import { extend } from '@react-three/fiber';
-import { Vector3 } from 'three';
-import { ReactNode } from 'react';
+import { shaderMaterial } from "@react-three/drei";
+import { extend } from "@react-three/fiber";
+import { Color, ShaderMaterial } from "three";
+import { ForwardedRef, forwardRef, useMemo } from "react";
+
+export type GradientUniforms = {
+  uColor1: { value: Color };
+  uColor2: { value: Color };
+  uColor3: { value: Color };
+  uColor4: { value: Color };
+  uTime: { value: number };
+  uAmp: { value: number };
+  uFreq: { value: number };
+};
+
+export type GradientShaderMaterial = ShaderMaterial & {
+  uniforms: GradientUniforms;
+};
 
 const GradientMaterialImpl = shaderMaterial(
   {
-    colorA: new Vector3(0.6, 0.6, 0.9),
-    colorB: new Vector3(0.9, 0.9, 1.0),
-    fresnelStrength: 1.0,
+    uColor1: new Color("#f1e8ff"),
+    uColor2: new Color("#e8d9ff"),
+    uColor3: new Color("#d9c4ff"),
+    uColor4: new Color("#ceb5ff"),
+    uTime: 0,
+    uAmp: 0.08,
+    uFreq: 1.25,
   },
-  // vertex shader
   /* glsl */ `
+    uniform float uTime;
+    uniform float uAmp;
+    uniform float uFreq;
+
     varying vec3 vNormal;
     varying vec3 vWorldPos;
+
     void main() {
-      vNormal = normalize(normalMatrix * normal);
-      vec4 worldPos = modelMatrix * vec4(position, 1.0);
+      vec3 displacedPosition = position;
+      float wave = sin((position.x + position.y + position.z) * uFreq + uTime) * uAmp;
+      displacedPosition += normal * wave;
+
+      vec4 worldPos = modelMatrix * vec4(displacedPosition, 1.0);
       vWorldPos = worldPos.xyz;
+      vNormal = normalize(normalMatrix * normal);
+
       gl_Position = projectionMatrix * viewMatrix * worldPos;
     }
   `,
-  // fragment shader
   /* glsl */ `
-    uniform vec3 colorA;
-    uniform vec3 colorB;
-    uniform float fresnelStrength;
+    uniform vec3 uColor1;
+    uniform vec3 uColor2;
+    uniform vec3 uColor3;
+    uniform vec3 uColor4;
+
     varying vec3 vNormal;
     varying vec3 vWorldPos;
+
+    vec3 sampleGradient(float h) {
+      vec3 c12 = mix(uColor1, uColor2, smoothstep(0.0, 0.33, h));
+      vec3 c23 = mix(uColor2, uColor3, smoothstep(0.33, 0.66, h));
+      vec3 c34 = mix(uColor3, uColor4, smoothstep(0.66, 1.0, h));
+
+      vec3 mixMid = mix(c12, c23, smoothstep(0.33, 0.66, h));
+      return mix(mixMid, c34, smoothstep(0.66, 1.0, h));
+    }
+
     void main() {
-      // Compute fresnel term based on the angle between the view ray and the normal
+      float height = clamp(vWorldPos.y * 0.3 + 0.5, 0.0, 1.0);
+      vec3 gradient = sampleGradient(height);
+
       vec3 viewDir = normalize(cameraPosition - vWorldPos);
-      float fresnel = pow(1.0 - max(dot(vNormal, viewDir), 0.0), 3.0);
-      // Map world Y coordinate into [0, 1] for the gradient
-      float h = clamp(vWorldPos.y * 0.5 + 0.5, 0.0, 1.0);
-      vec3 base = mix(colorA, colorB, h);
-      gl_FragColor = vec4(base + fresnel * fresnelStrength, 1.0);
+      vec3 normal = normalize(vNormal);
+      float fresnel = pow(1.0 - max(dot(normal, viewDir), 0.0), 3.0);
+
+      vec3 colour = gradient + fresnel * 0.45;
+      gl_FragColor = vec4(clamp(colour, 0.0, 1.0), 1.0);
     }
   `
-);
+) as unknown as { new (): GradientShaderMaterial };
 
-// Register the material so that it can be used as <gradientMaterial />
 extend({ GradientMaterial: GradientMaterialImpl });
 
 interface GradientMatProps {
-  colorA?: string;
-  colorB?: string;
-  fresnelStrength?: number;
-  children?: ReactNode;
+  colors?: [string, string, string, string];
+  uTime?: number;
+  uAmp?: number;
+  uFreq?: number;
 }
 
-/**
- * Thin wrapper around the shader material.  It converts colour props
- * from strings into Three.js colour vectors and forwards the
- * fresnelStrength uniform.  Usage:
- *
- * ```tsx
- * <mesh>
- *   <boxGeometry args={[1,1,1]} />
- *   <GradientMat colorA="#f00" colorB="#00f" fresnelStrength={2.0} />
- * </mesh>
- * ```
- */
-export default function GradientMat({ colorA, colorB, fresnelStrength }: GradientMatProps) {
+function GradientMat(
+  { colors, uTime, uAmp, uFreq }: GradientMatProps,
+  ref: ForwardedRef<GradientShaderMaterial>
+) {
+  const colorValues = useMemo(() => {
+    if (!colors) return undefined;
+    return colors.map((hex) => new Color(hex)) as [Color, Color, Color, Color];
+  }, [colors]);
+
   return (
-    // @ts-ignore – three-stdlib extends the JSX namespace at runtime
+    // @ts-ignore three-stdlib extends the JSX namespace at runtime
     <gradientMaterial
+      ref={ref}
       attach="material"
       args={[{}]}
-      colorA={colorA}
-      colorB={colorB}
-      fresnelStrength={fresnelStrength}
+      uColor1={colorValues?.[0]}
+      uColor2={colorValues?.[1]}
+      uColor3={colorValues?.[2]}
+      uColor4={colorValues?.[3]}
+      uTime={uTime}
+      uAmp={uAmp}
+      uFreq={uFreq}
     />
   );
 }
+
+export default forwardRef<GradientShaderMaterial, GradientMatProps>(GradientMat);
+export { GradientMaterialImpl };


### PR DESCRIPTION
## Summary
- redesign the GradientMat shader to expose four colour stops plus time-based wave uniforms
- drive ProceduralShapes materials via theme-aware palettes while reusing shader instances each frame
- refresh palette data, consumers, and documentation to reflect the new gradient structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac3a64040832fb2d5b067d79313a5