### PR TITLE
Enhance preloader readiness orchestration

### DIFF
--- a/components/three/ProceduralCanvas.tsx
+++ b/components/three/ProceduralCanvas.tsx
@@ -20,6 +20,7 @@ export type ProceduralCanvasProps = {
   variantOverride?: VariantState;
   palette?: GradientPalette;
   parallax?: boolean;
+  onStableFrame?: () => void;
 };
 
 const defaultCamera: CanvasCamera = {
@@ -43,6 +44,7 @@ export default function ProceduralCanvas({
   variantOverride,
   palette,
   parallax,
+  onStableFrame,
 }: ProceduralCanvasProps) {
   return (
     <Canvas
@@ -57,6 +59,7 @@ export default function ProceduralCanvas({
           variantOverride={variantOverride}
           palette={palette}
           parallax={parallax}
+          onStableFrame={onStableFrame}
         />
       </Suspense>
     </Canvas>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -68,7 +68,13 @@
   },
   "preloader": {
     "title": "Materializing shapes…",
-    "progress": "Loading {{value}}%"
+    "progress": "Loading {{value}}%",
+    "status": {
+      "fonts": "Preparing typography…",
+      "scene": "Warming up the 3D preview…",
+      "idle": "Stabilizing motion…",
+      "ready": "Ready to start!"
+    }
   },
   "experience": {
     "loadingFallback": "Materializing shapes…"

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -68,7 +68,13 @@
   },
   "preloader": {
     "title": "Materializando formas…",
-    "progress": "Carregando {{value}}%"
+    "progress": "Carregando {{value}}%",
+    "status": {
+      "fonts": "Preparando tipografia…",
+      "scene": "Aquecendo a prévia 3D…",
+      "idle": "Estabilizando o movimento…",
+      "ready": "Pronto para começar!"
+    }
   },
   "experience": {
     "loadingFallback": "Materializando formas…"


### PR DESCRIPTION
## Summary
- gate the preloader completion behind font loading, the first stable 3D frame, and a short idle delay while surfacing i18n status updates
- expose an `onStableFrame` callback from the procedural canvas stack to let the preloader detect the first stable render
- localize the new preloader status strings in both English and Portuguese

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd75fb518832fbacb17dfa56387d3