### PR TITLE
feat: add portrait wrapper and miniplayer to about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import Navbar from "../../components/Navbar";
 import { Trans, useTranslation } from "react-i18next";
 import Link from "next/link";
+import Image from "next/image";
 import "../i18n/config";
 
 import { getDefaultPalette } from "../../components/three/types";
@@ -55,9 +56,52 @@ export default function AboutPage() {
             </div>
           </section>
           <section className="flex flex-1 justify-center lg:justify-end">
-            <div className="relative h-72 w-72 max-w-full rounded-full border border-fg/10 bg-[radial-gradient(circle_at_30%_25%,rgba(255,223,245,0.45)_0%,rgba(205,231,255,0.22)_45%,transparent_80%)] shadow-[0_35px_90px_-45px_rgba(0,0,0,0.65)] backdrop-blur">
-              <div className="absolute inset-4 rounded-full border border-fg/20" aria-hidden />
-              <div className="absolute inset-0 animate-[spin_18s_linear_infinite] rounded-full border border-transparent border-t-fg/15" aria-hidden />
+            <div className="relative flex h-72 w-72 max-w-full flex-col items-center justify-center">
+              <div
+                className="pointer-events-none absolute inset-0 -z-10 rounded-full border border-fg/10 bg-[radial-gradient(circle_at_30%_25%,rgba(255,223,245,0.45)_0%,rgba(205,231,255,0.22)_45%,transparent_80%)] shadow-[0_35px_90px_-45px_rgba(0,0,0,0.65)] backdrop-blur"
+                aria-hidden
+              />
+              <div className="pointer-events-none absolute inset-0 animate-[spin_18s_linear_infinite] rounded-full border border-transparent border-t-fg/15" aria-hidden />
+
+              <div className="relative flex h-72 w-72 flex-col items-center justify-center gap-6">
+                <div className="relative h-44 w-44 overflow-hidden rounded-full border border-fg/20 bg-fg/5 shadow-[0_18px_40px_-24px_rgba(0,0,0,0.5)]">
+                  <Image
+                    src="/about-portrait.svg"
+                    alt={t("about.portraitAlt")}
+                    fill
+                    sizes="(min-width: 1024px) 18rem, 11rem"
+                    className="object-cover"
+                    priority
+                  />
+                </div>
+
+                <div className="relative w-full max-w-[15rem]">
+                  <div
+                    className="pointer-events-none absolute inset-0 -z-10 rounded-[1.8rem] bg-[conic-gradient(from_120deg_at_50%_50%,rgba(255,223,245,0.55),rgba(205,231,255,0.45),rgba(255,223,245,0.55))] opacity-75 blur-sm"
+                    aria-hidden
+                  />
+                  <Link
+                    href="https://open.spotify.com/track/5v0AIJfxNbu74eXZOyAOXl"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="relative flex items-center gap-3 rounded-2xl border border-fg/10 bg-bg/70 p-3 text-left shadow-[0_10px_40px_-25px_rgba(0,0,0,0.45)] backdrop-blur"
+                  >
+                    <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-xl border border-fg/15 bg-fg/10">
+                      <Image
+                        src="/about-portrait.svg"
+                        alt={t("about.miniplayer.coverAlt")}
+                        fill
+                        sizes="48px"
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-sm font-medium text-fg">{t("about.miniplayer.track")}</span>
+                      <span className="truncate text-xs text-fg/70">{t("about.miniplayer.artist")}</span>
+                    </div>
+                  </Link>
+                </div>
+              </div>
             </div>
           </section>
         </div>

--- a/public/about-portrait.svg
+++ b/public/about-portrait.svg
@@ -1,0 +1,21 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="256" fill="url(#paint0_radial)"/>
+  <path d="M256 120C209.399 120 171.5 157.899 171.5 204.5C171.5 251.101 209.399 289 256 289C302.601 289 340.5 251.101 340.5 204.5C340.5 157.899 302.601 120 256 120Z" fill="url(#paint1_radial)"/>
+  <path d="M135.143 382.172C150.029 330.911 199.659 293 256 293C312.341 293 361.971 330.911 376.857 382.172C381.499 398.573 369.042 414 352 414H160C142.958 414 130.501 398.573 135.143 382.172Z" fill="url(#paint2_linear)"/>
+  <defs>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(164 108) rotate(45) scale(430)">
+      <stop stop-color="#FFE4F6"/>
+      <stop offset="0.5" stop-color="#DCEBFF"/>
+      <stop offset="1" stop-color="#C0D3FF"/>
+    </radialGradient>
+    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(214 162) rotate(35) scale(170)">
+      <stop stop-color="#FFF6FB"/>
+      <stop offset="0.63" stop-color="#D5E6FF"/>
+      <stop offset="1" stop-color="#B5C9FF"/>
+    </radialGradient>
+    <linearGradient id="paint2_linear" x1="256" y1="293" x2="256" y2="414" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F9F0FF"/>
+      <stop offset="1" stop-color="#C2D8FF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,12 @@
       "second": "Within each engagement I mix rapid prototyping with Tailwind, Stripe integrations, API design, and MongoDB modelling to scale expressive products.",
       "third": "Between collaborations I research sound, motion, and generative design — explore my <github>GitHub</github> (@Duartois) to find living prototypes and open tools."
     },
+    "portraitAlt": "Portrait illustration of Duarte Duartois.",
+    "miniplayer": {
+      "track": "Liminal Echoes (Live Session)",
+      "artist": "Duartois",
+      "coverAlt": "Album art for the track Liminal Echoes."
+    },
     "visualCaption": "Animated organic avatar representing Duarte."
   },
   "contact": {

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -50,6 +50,12 @@
       "second": "Nos projetos, combino protótipos rápidos com Tailwind, integrações Stripe, design de APIs e modelagem em MongoDB para escalar produtos expressivos.",
       "third": "Entre colaborações, investigo som, motion e design generativo — explore meu <github>GitHub</github> (@Duartois) para ver protótipos vivos e ferramentas abertas."
     },
+    "portraitAlt": "Retrato ilustrado de Duarte Duartois.",
+    "miniplayer": {
+      "track": "Liminal Echoes (Live Session)",
+      "artist": "Duartois",
+      "coverAlt": "Capa do single Liminal Echoes."
+    },
     "visualCaption": "Avatar orgânico animado representando Duarte."
   },
   "contact": {


### PR DESCRIPTION
## Summary
- replace the about page gradient placeholder with a portrait image framed by the original animated halo
- add a stacked mini player card with accessible link, cover art, title, and artist metadata
- localize new alt text and labels in English and Portuguese and include an illustrative portrait asset

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1a39a73c832fa6fbf115345e38ac