### PR TITLE
Refine hero meshes and pointer steering

### DIFF
--- a/components/three/debug-helpers.ts
+++ b/components/three/debug-helpers.ts
@@ -6,6 +6,7 @@ export const createStateSnapshot = (state: ThreeAppState) =>
     variant: createVariantState(state.variant),
     palette: state.palette.map((stops) => [...stops]) as ThreeAppState["palette"],
     pointer: { ...state.pointer },
+    manualPointer: { ...state.manualPointer },
   });
 
 export const attachToWindow = (handle: ThreeAppHandle) => {

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -13,6 +13,10 @@ export type ShapeId =
 export type GradientStops = [string, string, string, string];
 export type GradientPalette = readonly GradientStops[];
 
+export type PointerDriver = "device" | "manual";
+
+export type PointerTarget = { x: number; y: number };
+
 export type VariantName = "home" | "about" | "work" | "contact" | "avatar";
 
 export type ShapeTransform = {
@@ -25,132 +29,132 @@ export type VariantState = Record<ShapeId, ShapeTransform>;
 export const variantMapping: Record<VariantName, VariantState> = {
   home: {
     torus270A: {
-      position: [-1.8, 1.35, 0.1],
-      rotation: [0.32, -0.1, 1.28],
+      position: [-2.15, 1.35, 0.35],
+      rotation: [0.54, -0.2, 1.45],
     },
     torus270B: {
-      position: [-1.6, -1.25, -0.05],
-      rotation: [-0.36, 0.12, -1.22],
+      position: [-1.55, -1.3, -0.45],
+      rotation: [-0.48, 0.45, -1.15],
     },
     semi180A: {
-      position: [1.18, 1.05, 0.14],
-      rotation: [0.26, 0.48, -0.32],
+      position: [1.4, 1.3, 0.1],
+      rotation: [0.65, 0.75, -0.22],
     },
     semi180B: {
-      position: [1.9, -0.72, -0.1],
-      rotation: [-0.34, -0.38, 0.54],
+      position: [2.3, -0.75, -0.28],
+      rotation: [-0.56, -0.62, 0.64],
     },
     wave: {
-      position: [0.6, 0.25, 0],
-      rotation: [0.1, 0.35, -0.28],
+      position: [0.45, 0.15, 0.35],
+      rotation: [0.68, 0.2, -0.48],
     },
     sphere: {
-      position: [2.35, -0.2, 0.08],
-      rotation: [0.22, -0.12, 0.58],
+      position: [2.35, 0.35, 0.52],
+      rotation: [0.35, -0.28, 0.42],
     },
   },
   about: {
     torus270A: {
-      position: [1.5, 1.65, 0.18],
-      rotation: [0.28, 0.06, 2.35],
+      position: [1.8, 1.6, 0.4],
+      rotation: [0.48, 0.32, 2.12],
     },
     torus270B: {
-      position: [-1.75, -1.4, -0.12],
-      rotation: [-0.34, -0.1, -2.18],
+      position: [-2.1, -1.5, -0.38],
+      rotation: [-0.5, -0.35, -2.05],
     },
     semi180A: {
-      position: [-0.35, 1.5, 0.08],
-      rotation: [0.3, 0.4, 1.7],
+      position: [-0.65, 1.65, 0.25],
+      rotation: [0.58, 0.95, 1.62],
     },
     semi180B: {
-      position: [1.65, 0.15, -0.06],
-      rotation: [-0.22, -0.45, 1.05],
+      position: [1.75, 0.2, -0.18],
+      rotation: [-0.45, -0.78, 1.18],
     },
     wave: {
-      position: [-2.15, 0.75, 0.04],
-      rotation: [0.12, 0.28, 0.95],
+      position: [-2.25, 0.8, 0.18],
+      rotation: [0.62, 0.48, 1.05],
     },
     sphere: {
-      position: [1.9, -1.85, 0.12],
-      rotation: [0.18, 0.16, 0.38],
+      position: [1.85, -1.95, 0.45],
+      rotation: [0.42, 0.25, 0.58],
     },
   },
   work: {
     torus270A: {
-      position: [-2.35, 1.85, 0.16],
-      rotation: [0.36, -0.22, 1.62],
+      position: [-2.45, 1.95, 0.35],
+      rotation: [0.62, -0.38, 1.72],
     },
     torus270B: {
-      position: [-0.85, -1.85, -0.08],
-      rotation: [-0.42, 0.18, -1.28],
+      position: [-0.95, -2.05, -0.42],
+      rotation: [-0.58, 0.32, -1.35],
     },
     semi180A: {
-      position: [0.4, 1.8, 0.12],
-      rotation: [0.38, 0.28, 1.32],
+      position: [0.3, 1.95, 0.28],
+      rotation: [0.68, 0.82, 1.42],
     },
     semi180B: {
-      position: [1.85, -0.1, -0.1],
-      rotation: [-0.28, -0.42, 0.62],
+      position: [1.95, -0.05, -0.25],
+      rotation: [-0.52, -0.74, 0.72],
     },
     wave: {
-      position: [1.55, 0.95, 0.02],
-      rotation: [0.22, -0.38, 0.22],
+      position: [1.65, 1.05, 0.1],
+      rotation: [0.75, -0.45, 0.35],
     },
     sphere: {
-      position: [2.95, -0.95, 0.1],
-      rotation: [0.34, 0.14, 0.28],
+      position: [3.05, -1.05, 0.55],
+      rotation: [0.55, 0.22, 0.38],
     },
   },
   contact: {
     torus270A: {
-      position: [0, 1.55, 0.1],
-      rotation: [0.16, 0.05, 0.08],
+      position: [0.25, 1.7, 0.32],
+      rotation: [0.52, 0.18, 0.28],
     },
     torus270B: {
-      position: [0, -1.55, -0.05],
-      rotation: [-0.18, -0.05, -0.12],
+      position: [-0.2, -1.65, -0.35],
+      rotation: [-0.52, -0.22, -0.32],
     },
     semi180A: {
-      position: [1.2, 0.95, 0.08],
-      rotation: [0.3, 0.35, 0.72],
+      position: [1.35, 1.0, 0.18],
+      rotation: [0.62, 0.85, 0.95],
     },
     semi180B: {
-      position: [-1.4, 0.2, -0.08],
-      rotation: [-0.3, -0.28, -0.68],
+      position: [-1.55, 0.3, -0.22],
+      rotation: [-0.62, -0.68, -0.85],
     },
     wave: {
-      position: [0, 0, 0],
-      rotation: [0.18, 0.32, 1.48],
+      position: [0.15, 0.05, 0.25],
+      rotation: [0.78, 0.48, 1.58],
     },
     sphere: {
-      position: [0.2, -0.1, 0.04],
-      rotation: [0.1, 0.08, 0.16],
+      position: [0.45, -0.05, 0.42],
+      rotation: [0.32, 0.2, 0.3],
     },
   },
   avatar: {
     torus270A: {
-      position: [0, 1.05, 0.08],
-      rotation: [0.3, 0.12, 0.24],
+      position: [0.1, 1.2, 0.28],
+      rotation: [0.65, 0.28, 0.45],
     },
     torus270B: {
-      position: [0, -1.05, -0.08],
-      rotation: [-0.3, -0.12, -0.24],
+      position: [-0.1, -1.15, -0.32],
+      rotation: [-0.65, -0.3, -0.45],
     },
     semi180A: {
-      position: [0.95, 0.85, 0.14],
-      rotation: [0.32, 0.4, 0.92],
+      position: [1.05, 0.95, 0.32],
+      rotation: [0.72, 0.95, 1.12],
     },
     semi180B: {
-      position: [-0.95, 0.35, -0.12],
-      rotation: [-0.34, -0.3, -0.82],
+      position: [-1.05, 0.4, -0.28],
+      rotation: [-0.72, -0.75, -1.02],
     },
     wave: {
-      position: [0, 0, 0.12],
-      rotation: [0.4, 0.2, 1.4],
+      position: [0.05, 0, 0.38],
+      rotation: [0.85, 0.52, 1.48],
     },
     sphere: {
-      position: [1.6, 0.2, 0.3],
-      rotation: [0.2, -0.15, 0.45],
+      position: [1.75, 0.35, 0.6],
+      rotation: [0.48, -0.35, 0.62],
     },
   },
 };
@@ -182,7 +186,10 @@ export type ThreeAppState = {
   theme: ThemeName;
   parallax: boolean;
   hovered: boolean;
-  pointer: { x: number; y: number };
+  cursorBoost: number;
+  pointer: PointerTarget;
+  pointerDriver: PointerDriver;
+  manualPointer: PointerTarget;
   ready: boolean;
 };
 


### PR DESCRIPTION
## Summary
- replace the placeholder torus and sphere primitives with bespoke arc, petal, ribbon, and ripple geometries plus tuned material animation settings
- sync every variant pose with the new meshes and extend the three.js scene state to support manual cursor boosts and pointer driving
- drive the navigation overlay with the new pointer controls and clone manual pointer data in debug snapshots for full state restoration

## Testing
- npx tsc --noEmit
- npm run verify:three *(fails: tsx not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1d2377e0832f93f37d1e29980452