### PR TITLE
Refine home hero copy and layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,37 @@
 "use client";
 
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
 import Link from "next/link";
 import Navbar from "../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
 import { getDefaultPalette } from "../components/three/types";
+import { WaveUnderline } from "../components/WaveUnderline";
 
 export default function HomePage() {
   const { t } = useTranslation("common");
+
+  const heroRoles = t("home.hero.subtitle")
+    .split("·")
+    .map((role) => role.trim())
+    .filter(Boolean);
+
+  const parseArrowLabel = (label: string) => {
+    const trimmed = label.trim();
+
+    if (trimmed.startsWith("→")) {
+      return {
+        arrow: "→",
+        text: trimmed.slice(1).trimStart(),
+      };
+    }
+
+    return { text: label };
+  };
+
+  const projectLabel = parseArrowLabel(t("home.hero.ctaProjects"));
+  const aboutLabel = parseArrowLabel(t("home.hero.ctaAbout"));
 
   useEffect(() => {
     window.__THREE_APP__?.setState((previous) => ({
@@ -25,29 +47,56 @@ export default function HomePage() {
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
         <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg" aria-hidden />
-        <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-8 px-6 text-center sm:gap-10">
-          <p className="text-xs font-medium uppercase tracking-[0.45em] text-fg/65 sm:text-sm">
-            {t("home.hero.kicker")}
-          </p>
-          <h1 className="text-balance text-4xl font-medium leading-tight text-fg sm:text-5xl md:text-6xl">
-            {t("home.hero.title")}
-          </h1>
-          <p className="max-w-2xl text-pretty text-base leading-relaxed text-fg/80 sm:text-lg">
-            {t("home.hero.subtitle")}
-          </p>
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <Link
-              href="/work"
-              className="rounded-full bg-fg px-8 py-3 text-sm font-medium uppercase tracking-[0.32em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-            >
-              {t("home.hero.ctaProjects")}
-            </Link>
-            <Link
-              href="/about"
-              className="rounded-full border border-fg/30 px-8 py-3 text-sm font-medium uppercase tracking-[0.32em] text-fg transition hover:border-fg/60 hover:bg-fg/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-            >
-              {t("home.hero.ctaAbout")}
-            </Link>
+        <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col justify-center gap-10 px-6 py-24 text-left sm:gap-12 sm:px-10 md:py-32">
+          <div className="flex flex-col gap-6 sm:gap-8">
+            <h1 className="text-balance text-4xl font-semibold uppercase leading-[1.05] tracking-[0.28em] text-fg sm:text-5xl md:text-6xl">
+              {t("home.hero.kicker")} {" "}
+              <WaveUnderline underlineClassName="text-brand-400">
+                <span className="tracking-[0.18em]">{t("home.hero.name")}</span>
+              </WaveUnderline>
+            </h1>
+            <h2 className="text-balance text-4xl font-semibold uppercase leading-[1.05] tracking-[0.28em] text-fg sm:text-5xl md:text-6xl">
+              {t("home.hero.title")} {" "}
+              <WaveUnderline underlineClassName="text-accent2-400">
+                <span className="tracking-[0.18em]">{t("home.hero.alias")}</span>
+              </WaveUnderline>
+            </h2>
+          </div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-8">
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-3 text-[0.65rem] font-medium uppercase tracking-[0.28em] text-fg/70 sm:text-xs md:text-sm">
+              {heroRoles.map((role, index) => (
+                <Fragment key={`${role}-${index}`}>
+                  <span>{role}</span>
+                  {index < heroRoles.length - 1 && (
+                    <span aria-hidden className="hidden h-1 w-1 rounded-full bg-fg/35 sm:inline-block" />
+                  )}
+                </Fragment>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-fg sm:text-xs md:text-sm">
+              <Link
+                href="/work"
+                className="group inline-flex items-center gap-2 transition-colors duration-200 hover:text-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-400 dark:hover:text-brand-300"
+              >
+                {projectLabel.arrow && (
+                  <span aria-hidden className="transition-transform duration-200 group-hover:translate-x-1 group-focus-visible:translate-x-1">
+                    {projectLabel.arrow}
+                  </span>
+                )}
+                <span className="tracking-[0.24em]">{projectLabel.text}</span>
+              </Link>
+              <Link
+                href="/about"
+                className="group inline-flex items-center gap-2 transition-colors duration-200 hover:text-accent2-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2-400"
+              >
+                {aboutLabel.arrow && (
+                  <span aria-hidden className="transition-transform duration-200 group-hover:translate-x-1 group-focus-visible:translate-x-1">
+                    {aboutLabel.arrow}
+                  </span>
+                )}
+                <span className="tracking-[0.24em]">{aboutLabel.text}</span>
+              </Link>
+            </div>
           </div>
         </section>
       </main>

--- a/components/WaveUnderline.tsx
+++ b/components/WaveUnderline.tsx
@@ -1,0 +1,31 @@
+import clsx from "classnames";
+import type { PropsWithChildren } from "react";
+
+type WaveUnderlineProps = PropsWithChildren<{
+  className?: string;
+  underlineClassName?: string;
+}>;
+
+const waveBackground =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 12'%3E%3Cpath fill='none' stroke='currentColor' stroke-width='3' d='M0 6c10-8 20 8 30 0s20-8 30 0 20 8 30 0 20-8 30 0'/%3E%3C/svg%3E\")";
+
+export function WaveUnderline({
+  children,
+  className,
+  underlineClassName,
+}: WaveUnderlineProps) {
+  return (
+    <span className={clsx("relative inline-flex flex-col", className)}>
+      <span className="relative z-10">{children}</span>
+      <span
+        aria-hidden
+        className={clsx("mt-2 h-2 overflow-hidden text-brand-400", underlineClassName)}
+      >
+        <span
+          className="block h-full w-full bg-repeat-x bg-[length:7.5rem_0.75rem] animate-wave"
+          style={{ backgroundImage: waveBackground }}
+        />
+      </span>
+    </span>
+  );
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,11 +10,13 @@
   },
   "home": {
     "hero": {
-      "kicker": "DUARTOIS IMMERSIVE PORTFOLIO",
-      "title": "Kinetic identities for brands embracing the future.",
-      "subtitle": "Digital experiences that fuse generative art, spatial sound, and interactive storytelling to spark new sensations.",
-      "ctaProjects": "explore projects",
-      "ctaAbout": "meet the story"
+      "kicker": "HEY, I'M",
+      "title": "BUT YOU CAN CALL ME",
+      "subtitle": "CREATIVE TECHNOLOGIST · GENERATIVE DESIGNER · AUDIOVISUAL DIRECTOR",
+      "name": "DUARTE",
+      "alias": "DUARTOIS",
+      "ctaProjects": "→ see my projects",
+      "ctaAbout": "→ meet the artist"
     }
   },
   "work": {

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -10,11 +10,13 @@
   },
   "home": {
     "hero": {
-      "kicker": "PORTFÓLIO IMERSIVO DE DUARTOIS",
-      "title": "Identidades cinéticas para marcas que abraçam o futuro.",
-      "subtitle": "Experiências digitais que misturam arte generativa, som espacial e narrativas interativas para despertar novos sentidos.",
-      "ctaProjects": "explorar projetos",
-      "ctaAbout": "conhecer trajetória"
+      "kicker": "OLÁ, SOU",
+      "title": "MAS PODES CHAMAR-ME DE",
+      "subtitle": "TECNÓLOGO CRIATIVO · DESIGNER GENERATIVO · DIRETOR AUDIOVISUAL",
+      "name": "DUARTE",
+      "alias": "DUARTOIS",
+      "ctaProjects": "→ ver os meus projetos",
+      "ctaAbout": "→ conhecer o artista"
     }
   },
   "work": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,15 @@ const config: Config = {
       transitionTimingFunction: {
         pleasant: "cubic-bezier(.22,.61,.36,1)",
       },
+      keyframes: {
+        wave: {
+          "0%": { backgroundPositionX: "0%" },
+          "100%": { backgroundPositionX: "100%" },
+        },
+      },
+      animation: {
+        wave: "wave 2.4s linear infinite",
+      },
     }
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- update the home hero copy in both locales with the new "HEY, I'M" / "BUT YOU CAN" voice and CTA text
- redesign the hero layout to stack the heading, add animated wave underlines, and align roles and links inline
- add a reusable `WaveUnderline` helper and Tailwind animation utilities to drive the underline treatment

## Testing
- `npm run build` *(fails: tsx command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc25a53878832fa2638f346b948c13