### PR TITLE
Add themed sun and moon icons to theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import clsx from "classnames";
 import { useTheme } from "@/app/theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
+import { MoonIcon, SunIcon } from "./icons/ThemeToggleIcons";
 
 export default function ThemeToggle() {
   const { theme, toggle } = useTheme();
@@ -21,12 +23,31 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      className="flex h-9 w-9 items-center justify-center rounded-full border border-fg/20 bg-bg/90 text-lg text-fg shadow-soft transition hover:border-fg/40 hover:bg-fg/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg dark:border-fg/30 dark:hover:border-fg/60"
+      className={clsx(
+        "group relative flex h-11 w-11 items-center justify-center rounded-full border bg-bg/90 text-fg shadow-soft transition-all duration-300 ease-pleasant",
+        "hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        theme === "dark"
+          ? "border-accent3-700/60 text-accent3-100 hover:border-accent3-400/80 hover:bg-accent3-900/40 focus-visible:outline-accent3-300/60"
+          : "border-brand-200/80 text-brand-700 hover:border-brand-400 hover:bg-brand-100/60 focus-visible:outline-brand-400/70",
+        theme === "dark"
+          ? "ring-1 ring-accent3-500/40"
+          : "ring-1 ring-brand-400/50",
+      )}
       aria-label={t("themeToggle.ariaLabel", { theme: nextThemeLabel })}
       aria-pressed={theme === "dark"}
       title={t("themeToggle.title", { theme: titleThemeLabel })}
     >
-      <span aria-hidden>{theme === "dark" ? "🌙" : "☀️"}</span>
+      {theme === "dark" ? (
+        <MoonIcon
+          aria-hidden
+          className="h-6 w-6 transform transition-transform duration-300 ease-pleasant group-active:scale-95"
+        />
+      ) : (
+        <SunIcon
+          aria-hidden
+          className="h-6 w-6 transform transition-transform duration-300 ease-pleasant group-active:scale-95"
+        />
+      )}
     </button>
   );
 }

--- a/components/icons/ThemeToggleIcons.tsx
+++ b/components/icons/ThemeToggleIcons.tsx
@@ -1,0 +1,78 @@
+import clsx from "classnames";
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement> & {
+  className?: string;
+};
+
+export function SunIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden
+      focusable="false"
+      className={clsx(
+        "h-6 w-6 text-brand-500 drop-shadow-sm transition-transform duration-300 ease-pleasant",
+        className,
+      )}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="4.75" className="fill-current opacity-95" />
+      <circle
+        cx="12"
+        cy="12"
+        r="6.25"
+        className="stroke-current opacity-35"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <g
+        className="stroke-current opacity-70"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <line x1="12" y1="2.5" x2="12" y2="5.2" />
+        <line x1="12" y1="18.8" x2="12" y2="21.5" />
+        <line x1="4.2" y1="12" x2="6.9" y2="12" />
+        <line x1="17.1" y1="12" x2="19.8" y2="12" />
+        <line x1="5.5" y1="5.5" x2="7.4" y2="7.4" />
+        <line x1="16.6" y1="16.6" x2="18.5" y2="18.5" />
+        <line x1="16.6" y1="7.4" x2="18.5" y2="5.5" />
+        <line x1="5.5" y1="18.5" x2="7.4" y2="16.6" />
+      </g>
+      <circle cx="12" cy="12" r="2.75" className="fill-brand-100 opacity-90" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden
+      focusable="false"
+      className={clsx(
+        "h-6 w-6 text-accent3-200 drop-shadow-sm transition-transform duration-300 ease-pleasant",
+        className,
+      )}
+      {...props}
+    >
+      <path
+        className="fill-current"
+        d="M16.84 4.22a.75.75 0 0 1 .91-.91 9.75 9.75 0 1 1-12.62 12.62.75.75 0 0 1 .91-.91 7.5 7.5 0 0 0 10.8-10.8Z"
+      />
+      <path
+        className="fill-accent3-100/70"
+        d="M14.1 6.35a5.25 5.25 0 0 0-4.67 7.52 5.25 5.25 0 0 1 7.59-7.59 5.23 5.23 0 0 0-2.92-.93Z"
+      />
+      <g className="fill-current opacity-80">
+        <circle cx="6.75" cy="6.75" r="1" className="opacity-70" />
+        <circle cx="18.25" cy="8.5" r="0.65" className="opacity-60" />
+        <circle cx="9.5" cy="18" r="0.85" className="opacity-50" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add stylized SunIcon and MoonIcon components that match the palette
- update the theme toggle button to use the new icons and refreshed Tailwind styling

## Testing
- npm run build *(fails: tsx not found in PATH during verify:three script)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3a88d5a0832f800b4cca7ae0439b