### PR TITLE
Add animated menu toggle icon to navbar

### DIFF
--- a/components/MenuToggleIcon.tsx
+++ b/components/MenuToggleIcon.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ComponentPropsWithoutRef } from "react";
+
+type MenuToggleIconProps = {
+  isOpen: boolean;
+} & Omit<ComponentPropsWithoutRef<"svg">, "viewBox">;
+
+const transition = {
+  duration: 0.4,
+  ease: [0.4, 0, 0.2, 1],
+};
+
+export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggleIconProps) {
+  const composedClassName = ["relative", className].filter(Boolean).join(" ");
+
+  return (
+    <motion.svg
+      viewBox="0 0 24 24"
+      width={24}
+      height={24}
+      className={composedClassName}
+      initial={false}
+      animate={isOpen ? "open" : "closed"}
+      {...rest}
+    >
+      <motion.path
+        variants={{
+          closed: {
+            d: "M5 7.5h14",
+          },
+          open: {
+            d: "M6.2 6.2l11.6 11.6",
+          },
+        }}
+        transition={transition}
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+      <motion.path
+        variants={{
+          closed: {
+            opacity: 1,
+            d: "M5 12h14",
+          },
+          open: {
+            opacity: 0,
+            d: "M12 12h0",
+          },
+        }}
+        transition={transition}
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+      <motion.path
+        variants={{
+          closed: {
+            d: "M5 16.5h14",
+          },
+          open: {
+            d: "M17.8 6.2L6.2 17.8",
+          },
+        }}
+        transition={transition}
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+    </motion.svg>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { motion } from "framer-motion";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -8,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
 
 import LanguageSwitcher from "./LanguageSwitcher";
+import MenuToggleIcon from "./MenuToggleIcon";
 import NavOverlay from "./NavOverlay";
 import ThemeToggle from "./ThemeToggle";
 
@@ -119,30 +118,14 @@ export default function Navbar() {
               aria-haspopup="dialog"
               aria-expanded={isOpen}
               aria-controls="main-navigation-overlay"
-              className="group flex h-12 w-12 items-center justify-center rounded-full border border-fg/20 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition hover:border-fg/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+              className="group relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-fg/15 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition-colors duration-300 hover:border-fg/40 hover:bg-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
             >
               <span className="sr-only">{isOpen ? t("navbar.close") : t("navbar.open")}</span>
-              <span aria-hidden="true" className="grid grid-cols-3 gap-1.5">
-                {Array.from({ length: 9 }).map((_, index) => (
-                  <motion.span
-                    key={index}
-                    layout
-                    className="h-1.5 w-1.5 rounded-full bg-fg transition group-hover:scale-110 group-focus-visible:scale-110"
-                    animate={
-                      isOpen
-                        ? {
-                            scale: 0.6,
-                            opacity: 0.35,
-                          }
-                        : {
-                            scale: 1,
-                            opacity: 1,
-                          }
-                    }
-                    transition={{ duration: 0.3, ease: "easeInOut" }}
-                  />
-                ))}
-              </span>
+              <MenuToggleIcon
+                aria-hidden="true"
+                isOpen={isOpen}
+                className="h-6 w-6 text-fg transition-colors duration-300 group-hover:text-fg group-focus-visible:text-fg"
+              />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a reusable MenuToggleIcon component that animates between hamburger and close states
- swap the navbar toggle grid for the new animated icon and update button styling

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc3df8eb18832fbf2ecee3c5d42716