### PR TITLE
Refine blob geometries and variant layout

### DIFF
--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -29,132 +29,132 @@ export type VariantState = Record<ShapeId, ShapeTransform>;
 export const variantMapping: Record<VariantName, VariantState> = {
   home: {
     torus270A: {
-      position: [-2.15, 1.35, 0.35],
-      rotation: [0.54, -0.2, 1.45],
+      position: [-1.95, 1.4, 0.28],
+      rotation: [0.55, -0.32, 1.32],
     },
     torus270B: {
-      position: [-1.55, -1.3, -0.45],
-      rotation: [-0.48, 0.45, -1.15],
+      position: [-1.35, -1.25, -0.42],
+      rotation: [-0.58, 0.36, -1.08],
     },
     semi180A: {
-      position: [1.4, 1.3, 0.1],
-      rotation: [0.65, 0.75, -0.22],
+      position: [1.35, 1.2, 0.22],
+      rotation: [0.62, 0.82, -0.18],
     },
     semi180B: {
-      position: [2.3, -0.75, -0.28],
-      rotation: [-0.56, -0.62, 0.64],
+      position: [2.15, -0.65, -0.34],
+      rotation: [-0.5, -0.6, 0.54],
     },
     wave: {
-      position: [0.45, 0.15, 0.35],
-      rotation: [0.68, 0.2, -0.48],
+      position: [0.4, 0.05, 0.38],
+      rotation: [0.68, 0.16, -0.48],
     },
     sphere: {
-      position: [2.35, 0.35, 0.52],
-      rotation: [0.35, -0.28, 0.42],
+      position: [2.25, 0.42, 0.56],
+      rotation: [0.36, -0.24, 0.32],
     },
   },
   about: {
     torus270A: {
-      position: [1.8, 1.6, 0.4],
-      rotation: [0.48, 0.32, 2.12],
+      position: [1.75, 1.65, 0.34],
+      rotation: [0.48, 0.35, 2.1],
     },
     torus270B: {
-      position: [-2.1, -1.5, -0.38],
-      rotation: [-0.5, -0.35, -2.05],
+      position: [-2.3, -1.4, -0.36],
+      rotation: [-0.55, -0.32, -2.0],
     },
     semi180A: {
-      position: [-0.65, 1.65, 0.25],
-      rotation: [0.58, 0.95, 1.62],
+      position: [-0.55, 1.7, 0.26],
+      rotation: [0.6, 0.98, 1.52],
     },
     semi180B: {
-      position: [1.75, 0.2, -0.18],
-      rotation: [-0.45, -0.78, 1.18],
+      position: [1.85, 0.15, -0.22],
+      rotation: [-0.42, -0.82, 1.08],
     },
     wave: {
-      position: [-2.25, 0.8, 0.18],
-      rotation: [0.62, 0.48, 1.05],
+      position: [-2.15, 0.72, 0.2],
+      rotation: [0.66, 0.5, 1.08],
     },
     sphere: {
-      position: [1.85, -1.95, 0.45],
-      rotation: [0.42, 0.25, 0.58],
+      position: [1.95, -1.9, 0.5],
+      rotation: [0.44, 0.28, 0.54],
     },
   },
   work: {
     torus270A: {
-      position: [-2.45, 1.95, 0.35],
-      rotation: [0.62, -0.38, 1.72],
+      position: [-2.35, 2.05, 0.38],
+      rotation: [0.6, -0.4, 1.68],
     },
     torus270B: {
-      position: [-0.95, -2.05, -0.42],
-      rotation: [-0.58, 0.32, -1.35],
+      position: [-0.85, -2.1, -0.4],
+      rotation: [-0.6, 0.34, -1.28],
     },
     semi180A: {
-      position: [0.3, 1.95, 0.28],
-      rotation: [0.68, 0.82, 1.42],
+      position: [0.4, 2.05, 0.3],
+      rotation: [0.7, 0.86, 1.35],
     },
     semi180B: {
-      position: [1.95, -0.05, -0.25],
-      rotation: [-0.52, -0.74, 0.72],
+      position: [2.05, -0.1, -0.28],
+      rotation: [-0.5, -0.76, 0.68],
     },
     wave: {
-      position: [1.65, 1.05, 0.1],
-      rotation: [0.75, -0.45, 0.35],
+      position: [1.55, 1.0, 0.14],
+      rotation: [0.78, -0.42, 0.32],
     },
     sphere: {
-      position: [3.05, -1.05, 0.55],
-      rotation: [0.55, 0.22, 0.38],
+      position: [3.0, -1.0, 0.58],
+      rotation: [0.5, 0.18, 0.36],
     },
   },
   contact: {
     torus270A: {
-      position: [0.25, 1.7, 0.32],
-      rotation: [0.52, 0.18, 0.28],
+      position: [0.3, 1.75, 0.3],
+      rotation: [0.5, 0.2, 0.24],
     },
     torus270B: {
-      position: [-0.2, -1.65, -0.35],
-      rotation: [-0.52, -0.22, -0.32],
+      position: [-0.1, -1.7, -0.32],
+      rotation: [-0.55, -0.24, -0.28],
     },
     semi180A: {
-      position: [1.35, 1.0, 0.18],
-      rotation: [0.62, 0.85, 0.95],
+      position: [1.4, 1.05, 0.2],
+      rotation: [0.64, 0.88, 0.9],
     },
     semi180B: {
-      position: [-1.55, 0.3, -0.22],
-      rotation: [-0.62, -0.68, -0.85],
+      position: [-1.45, 0.35, -0.24],
+      rotation: [-0.66, -0.7, -0.8],
     },
     wave: {
-      position: [0.15, 0.05, 0.25],
-      rotation: [0.78, 0.48, 1.58],
+      position: [0.2, 0.08, 0.28],
+      rotation: [0.82, 0.52, 1.52],
     },
     sphere: {
-      position: [0.45, -0.05, 0.42],
-      rotation: [0.32, 0.2, 0.3],
+      position: [0.55, -0.02, 0.44],
+      rotation: [0.34, 0.24, 0.28],
     },
   },
   avatar: {
     torus270A: {
-      position: [0.1, 1.2, 0.28],
-      rotation: [0.65, 0.28, 0.45],
+      position: [0.15, 1.25, 0.26],
+      rotation: [0.62, 0.3, 0.4],
     },
     torus270B: {
-      position: [-0.1, -1.15, -0.32],
-      rotation: [-0.65, -0.3, -0.45],
+      position: [-0.05, -1.2, -0.3],
+      rotation: [-0.66, -0.32, -0.4],
     },
     semi180A: {
-      position: [1.05, 0.95, 0.32],
-      rotation: [0.72, 0.95, 1.12],
+      position: [1.1, 1.0, 0.34],
+      rotation: [0.74, 0.98, 1.08],
     },
     semi180B: {
-      position: [-1.05, 0.4, -0.28],
-      rotation: [-0.72, -0.75, -1.02],
+      position: [-0.98, 0.45, -0.3],
+      rotation: [-0.74, -0.78, -0.98],
     },
     wave: {
-      position: [0.05, 0, 0.38],
-      rotation: [0.85, 0.52, 1.48],
+      position: [0.08, 0.02, 0.4],
+      rotation: [0.88, 0.56, 1.42],
     },
     sphere: {
-      position: [1.75, 0.35, 0.6],
-      rotation: [0.48, -0.35, 0.62],
+      position: [1.82, 0.38, 0.62],
+      rotation: [0.5, -0.32, 0.58],
     },
   },
 };


### PR DESCRIPTION
## Summary
- reshape the arc, petal, ribbon and ripple sphere factories with bespoke control points so the meshes match the target silhouettes and include baked-in scaling
- refresh `createGeometries` and every variant transform to use the new forms and align the composition

## Testing
- npm run verify:three

------
https://chatgpt.com/codex/tasks/task_e_68dc4be5c8b0832f9217378d23c2fa7b