### PR TITLE
Adjust z-index layering for 3D canvas

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -25,7 +25,7 @@ export default function AboutPage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
         <div className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-16">
           <section className="flex-1 space-y-6">
             <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -31,7 +31,7 @@ export default function ContactPage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-bg/45 via-bg/85 to-bg" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-bg/45 via-bg/85 to-bg" aria-hidden />
         <div className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left">
           <div className="space-y-4">
             <h1 className="text-4xl font-semibold text-fg sm:text-5xl">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ export default function HomePage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg" aria-hidden />
         <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col justify-center gap-10 px-6 py-24 text-left sm:gap-12 sm:px-10 md:py-32">
           <div className="flex flex-col gap-6 sm:gap-8">
             <h1 className="text-balance text-4xl font-semibold uppercase leading-[1.05] tracking-[0.28em] text-fg sm:text-5xl md:text-6xl">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -113,7 +113,7 @@ export default function WorkPage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
         <div className="relative z-10 mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20">
           <section className="lg:w-1/2">
             <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -13,7 +13,7 @@ export default function CanvasRoot() {
 
   return (
     <div
-      className="pointer-events-none fixed inset-0 -z-20 overflow-visible"
+      className="pointer-events-none fixed inset-0 -z-5 overflow-visible"
       aria-hidden
     >
       {mounted ? <CoreCanvas /> : null}


### PR DESCRIPTION
## Summary
- raise the Three.js canvas wrapper z-index so it renders above background ornaments
- drop each page-level gradient overlay z-index so they remain behind the canvas layer

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68dc4e61ab84832fb972e756d47405f7