### PR TITLE
Sharlee-inspired hero redesign and palette refresh

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,50 +1,112 @@
 @import "tailwindcss";
 
 :root {
-  --color-bg: 244 247 255;      /* fallback pastel sky */
-  --color-fg: 30 36 46;         /* suave e legível */
-  --color-muted: 122 136 158;   /* detalhes discretos */
+  --color-bg: 246 243 255;
+  --color-fg: 27 22 46;
+  --color-muted: 132 124 174;
+  --glow-lilac: 218 184 255;
+  --glow-mint: 158 255 210;
 }
 
 /* Modo claro */
 :root[data-theme="light"], :root.light {
-  --color-bg: 244 247 255;      /* fundo pastel azulado */
-  --color-fg: 28 32 45;         /* texto levemente frio */
-  --color-muted: 130 142 164;   /* elementos secundários */
+  --color-bg: 246 243 255;
+  --color-fg: 27 22 46;
+  --color-muted: 132 124 174;
+  --glow-lilac: 218 184 255;
+  --glow-mint: 158 255 210;
 }
 
 /* Modo escuro */
 :root[data-theme="dark"], :root.dark {
-  --color-bg: 6 8 12;           /* preto profundo */
-  --color-fg: 230 236 250;      /* texto claro vívido */
-  --color-muted: 140 154 174;   /* destaque suave em contraste */
+  --color-bg: 15 12 26;
+  --color-fg: 236 233 255;
+  --color-muted: 164 158 210;
+  --glow-lilac: 120 78 180;
+  --glow-mint: 68 172 156;
 }
 
 /* 2) Reset & base */
 html, body, #__next { height: 100% }
 html, body {
-  background: rgb(var(--color-bg));
+  background: radial-gradient(circle at 20% 0%, rgb(var(--glow-lilac) / 0.6), transparent 55%),
+    radial-gradient(circle at 80% 20%, rgb(var(--glow-mint) / 0.45), transparent 60%),
+    linear-gradient(140deg, rgb(var(--glow-lilac) / 0.35), rgb(var(--glow-mint) / 0.3));
   color: rgb(var(--color-fg));
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
 .btn {
-  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-[transform,box-shadow,background-color,color] duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
-  @apply shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] hover:scale-[1.02] active:scale-[0.98];
-  background: linear-gradient(180deg, #7ab6ff, #2a63e6);
-  color: white;
+  @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-medium lowercase tracking-[0.08em] transition-[transform,box-shadow,background-color,color] duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
+  @apply shadow-[0_10px_30px_-12px_rgba(112,81,155,0.55)] hover:scale-[1.03] active:scale-[0.97];
+  background: linear-gradient(135deg, rgb(var(--glow-lilac) / 0.95), rgb(var(--glow-mint) / 0.95));
+  color: rgb(var(--color-fg));
+  backdrop-filter: blur(16px);
 }
 .btn-secondary {
-  @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
-  background: rgb(var(--color-fg) / 0.07);
+  @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-medium lowercase tracking-[0.08em] transition duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
+  background: rgb(var(--color-fg) / 0.08);
   color: rgb(var(--color-fg));
+  backdrop-filter: blur(12px);
 }
 .link {
   @apply underline underline-offset-4 decoration-transparent hover:decoration-current transition-colors duration-300 ease-[cubic-bezier(.22,.61,.36,1)];
 }
 
+.hero-button {
+  @apply inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-medium lowercase tracking-[0.12em] transition-[background-color,box-shadow,transform,color] duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
+  background: rgb(var(--glow-lilac) / 0.35);
+  color: rgb(var(--color-fg));
+  backdrop-filter: blur(22px);
+  box-shadow: 0 10px 30px -12px rgba(62, 44, 102, 0.45);
+}
+.hero-button:hover,
+.hero-button:focus-visible {
+  @apply outline-none;
+  background: rgb(var(--glow-mint) / 0.45);
+  color: rgb(var(--color-fg));
+  transform: translateY(-1px);
+}
+.hero-button--ghost {
+  background: rgb(var(--color-fg) / 0.08);
+  color: rgb(var(--color-fg));
+}
+.hero-button--ghost:hover,
+.hero-button--ghost:focus-visible {
+  background: rgb(var(--glow-lilac) / 0.4);
+}
+
+.hero-animate {
+  animation: hero-fade 0.9s cubic-bezier(.22,.61,.36,1) both;
+}
+.hero-animate[data-hero-index="1"] {
+  animation-delay: 0.12s;
+}
+.hero-animate[data-hero-index="2"] {
+  animation-delay: 0.24s;
+}
+.hero-animate[data-hero-index="3"] {
+  animation-delay: 0.36s;
+}
+
+@keyframes hero-fade {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* 4) Acessibilidade: reduz animações */
 @media (prefers-reduced-motion: reduce) {
-  .btn, .btn-secondary, .link { transition: none !important; }
+  .btn, .btn-secondary, .link, .hero-button {
+    transition: none !important;
+  }
+  .hero-animate {
+    animation: none !important;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,37 +1,15 @@
 "use client";
 
-import { Fragment, useEffect } from "react";
+import { useEffect } from "react";
 import Link from "next/link";
 import Navbar from "../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
 import { getDefaultPalette } from "../components/three/types";
-import { WaveUnderline } from "../components/WaveUnderline";
 
 export default function HomePage() {
   const { t } = useTranslation("common");
-
-  const heroRoles = t("home.hero.subtitle")
-    .split("·")
-    .map((role) => role.trim())
-    .filter(Boolean);
-
-  const parseArrowLabel = (label: string) => {
-    const trimmed = label.trim();
-
-    if (trimmed.startsWith("→")) {
-      return {
-        arrow: "→",
-        text: trimmed.slice(1).trimStart(),
-      };
-    }
-
-    return { text: label };
-  };
-
-  const projectLabel = parseArrowLabel(t("home.hero.ctaProjects"));
-  const aboutLabel = parseArrowLabel(t("home.hero.ctaAbout"));
 
   useEffect(() => {
     window.__THREE_APP__?.setState((previous) => ({
@@ -46,55 +24,32 @@ export default function HomePage() {
     <>
       <Navbar />
       <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-brand-200/55 via-bg/70 to-bg dark:from-accent2-700/35 dark:via-bg/80 dark:to-bg" aria-hidden />
-        <section className="relative z-10 mx-auto flex min-h-screen max-w-5xl flex-col justify-center gap-10 px-6 py-24 text-left sm:gap-12 sm:px-10 md:py-32">
-          <div className="flex flex-col gap-6 sm:gap-8">
-            <h1 className="text-balance text-4xl font-semibold uppercase leading-[1.05] tracking-[0.28em] text-fg sm:text-5xl md:text-6xl">
-              {t("home.hero.kicker")} {" "}
-              <WaveUnderline underlineClassName="text-brand-400">
-                <span className="tracking-[0.18em]">{t("home.hero.name")}</span>
-              </WaveUnderline>
+        <div
+          className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.48),_transparent_55%),_linear-gradient(140deg,_rgba(218,184,255,0.55),_rgba(140,255,216,0.4))] dark:bg-[radial-gradient(circle_at_top,_rgba(46,20,64,0.65),_transparent_55%),_linear-gradient(140deg,_rgba(77,32,104,0.7),_rgba(23,94,87,0.55))]" aria-hidden
+        />
+        <section className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32">
+          <div className="flex w-full max-w-3xl flex-col items-center gap-8 sm:gap-10">
+            <span className="hero-animate text-sm font-light lowercase tracking-[0.28em] text-muted/80 sm:text-base" data-hero-index="0">
+              {t("home.hero.kicker")}
+            </span>
+            <h1 className="hero-animate text-balance text-4xl font-light lowercase leading-tight text-fg sm:text-5xl md:text-6xl" data-hero-index="1">
+              {t("home.hero.title")}
             </h1>
-            <h2 className="text-balance text-4xl font-semibold uppercase leading-[1.05] tracking-[0.28em] text-fg sm:text-5xl md:text-6xl">
-              {t("home.hero.title")} {" "}
-              <WaveUnderline underlineClassName="text-accent2-400">
-                <span className="tracking-[0.18em]">{t("home.hero.alias")}</span>
-              </WaveUnderline>
-            </h2>
-          </div>
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-8">
-            <div className="flex flex-wrap items-center gap-x-5 gap-y-3 text-[0.65rem] font-medium uppercase tracking-[0.28em] text-fg/70 sm:text-xs md:text-sm">
-              {heroRoles.map((role, index) => (
-                <Fragment key={`${role}-${index}`}>
-                  <span>{role}</span>
-                  {index < heroRoles.length - 1 && (
-                    <span aria-hidden className="hidden h-1 w-1 rounded-full bg-fg/35 sm:inline-block" />
-                  )}
-                </Fragment>
-              ))}
-            </div>
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-fg sm:text-xs md:text-sm">
+            <p className="hero-animate max-w-2xl text-pretty text-base font-light lowercase text-muted sm:text-lg" data-hero-index="2">
+              {t("home.hero.subtitle")}
+            </p>
+            <div className="hero-animate flex flex-col items-center gap-3 sm:flex-row" data-hero-index="3">
               <Link
                 href="/work"
-                className="group inline-flex items-center gap-2 transition-colors duration-200 hover:text-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-400 dark:hover:text-brand-300"
+                className="hero-button"
               >
-                {projectLabel.arrow && (
-                  <span aria-hidden className="transition-transform duration-200 group-hover:translate-x-1 group-focus-visible:translate-x-1">
-                    {projectLabel.arrow}
-                  </span>
-                )}
-                <span className="tracking-[0.24em]">{projectLabel.text}</span>
+                {t("home.hero.ctaProjects")}
               </Link>
               <Link
                 href="/about"
-                className="group inline-flex items-center gap-2 transition-colors duration-200 hover:text-accent2-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent2-400"
+                className="hero-button hero-button--ghost"
               >
-                {aboutLabel.arrow && (
-                  <span aria-hidden className="transition-transform duration-200 group-hover:translate-x-1 group-focus-visible:translate-x-1">
-                    {aboutLabel.arrow}
-                  </span>
-                )}
-                <span className="tracking-[0.24em]">{aboutLabel.text}</span>
+                {t("home.hero.ctaAbout")}
               </Link>
             </div>
           </div>

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -28,27 +28,27 @@ export type VariantState = Record<ShapeId, ShapeTransform>;
 
 const createFramedVariant = (): VariantState => ({
   torus270A: {
-    position: [-1.92, 1.42, 0.18],
-    rotation: [0, 0, 0],
+    position: [-1.68, 1.58, 0.16],
+    rotation: [0.08, -0.1, 0.04],
   },
   torus270B: {
-    position: [-1.28, -1.22, -0.4],
-    rotation: [0, 0, 0],
+    position: [-1.86, -1.24, -0.36],
+    rotation: [-0.12, 0.18, 0.28],
   },
   semi180A: {
-    position: [1.32, 1.18, 0.18],
-    rotation: [0, 0, 0],
+    position: [1.74, 1.36, 0.18],
+    rotation: [-0.05, 0.06, -0.08],
   },
   semi180B: {
-    position: [2.18, -0.6, -0.32],
-    rotation: [0, 0, 0],
+    position: [2.04, -0.92, -0.28],
+    rotation: [0.07, -0.05, -0.22],
   },
   wave: {
-    position: [0.36, 0.04, 0.34],
-    rotation: [0, 0, 0],
+    position: [0.08, 0.18, 0.42],
+    rotation: [0, 0, 0.08],
   },
   sphere: {
-    position: [2.22, 0.42, 0.52],
+    position: [0.96, -1.4, 0.54],
     rotation: [0, 0, 0],
   },
 });
@@ -62,21 +62,21 @@ export const variantMapping: Record<VariantName, VariantState> = {
 };
 
 export const LIGHT_THEME_PALETTE: GradientPalette = [
-  ["#f4ebff", "#dcc8ff", "#c1a6ff", "#9d7aff"],
-  ["#ffe8f1", "#ffc4dd", "#ff9ec8", "#ff6faa"],
-  ["#d0fff9", "#a7f5ef", "#76e0df", "#2fc4c3"],
-  ["#ebffd4", "#c7f7a2", "#a0ed75", "#7bd74b"],
-  ["#fff0dd", "#ffd5aa", "#ffb877", "#ff9042"],
-  ["#deecff", "#b8d2ff", "#8ab2ff", "#5a8cff"],
+  ["#f9e9ff", "#e6c7ff", "#d0a4ff", "#b67cff"],
+  ["#ffe9fb", "#ffc4ef", "#ffa1e3", "#ff77d2"],
+  ["#e8fff6", "#c2ffe6", "#99f7d6", "#64e8c2"],
+  ["#f3ffe6", "#d8ffb8", "#baff85", "#8af55d"],
+  ["#fff4e5", "#ffd5b5", "#ffb886", "#ff9362"],
+  ["#e9f6ff", "#c3e4ff", "#9accff", "#6faeff"],
 ];
 
 export const DARK_THEME_PALETTE: GradientPalette = [
-  ["#241a44", "#3d2972", "#5f3aa9", "#9b6cf5"],
-  ["#2a0d21", "#4f183c", "#862a64", "#e75b9a"],
-  ["#07272c", "#0d4149", "#156a6c", "#2fd6cc"],
-  ["#112215", "#1a3821", "#295631", "#6cd551"],
-  ["#331c0b", "#4d2a12", "#753e1a", "#e0762d"],
-  ["#0d192d", "#192941", "#2a4669", "#4f7ecc"],
+  ["#2b1a44", "#3c2b63", "#5b3f96", "#8e63e6"],
+  ["#3b1031", "#5a1f50", "#872c77", "#ff63c5"],
+  ["#0a2c25", "#11433a", "#146259", "#21d7a8"],
+  ["#12240f", "#1d3a18", "#2a5927", "#6dff63"],
+  ["#331d0f", "#4d2a16", "#72401f", "#ffa564"],
+  ["#12203c", "#1c3056", "#2f4f8b", "#6aa7ff"],
 ];
 
 export type ThemeName = "light" | "dark";

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,13 +10,11 @@
   },
   "home": {
     "hero": {
-      "kicker": "HEY, I'M",
-      "title": "BUT YOU CAN CALL ME",
-      "subtitle": "CREATIVE TECHNOLOGIST · GENERATIVE DESIGNER · AUDIOVISUAL DIRECTOR",
-      "name": "DUARTE",
-      "alias": "DUARTOIS",
-      "ctaProjects": "→ see my projects",
-      "ctaAbout": "→ meet the artist"
+      "kicker": "creative technologist & art director from lisbon",
+      "title": "i weave neon, sound, and immersive code into sensorial stories.",
+      "subtitle": "i collaborate with studios and performers to craft reactive identities, experiential stages, and living visuals.",
+      "ctaProjects": "+ see my projects",
+      "ctaAbout": "+ more about me"
     }
   },
   "work": {

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -10,13 +10,11 @@
   },
   "home": {
     "hero": {
-      "kicker": "OLÁ, SOU",
-      "title": "MAS PODES CHAMAR-ME DE",
-      "subtitle": "TECNÓLOGO CRIATIVO · DESIGNER GENERATIVO · DIRETOR AUDIOVISUAL",
-      "name": "DUARTE",
-      "alias": "DUARTOIS",
-      "ctaProjects": "→ ver os meus projetos",
-      "ctaAbout": "→ conhecer o artista"
+      "kicker": "tecnólogo criativo & diretor de arte em lisboa",
+      "title": "teço neon, som e código imersivo em histórias sensoriais.",
+      "subtitle": "colaboro com estúdios e performers para criar identidades reativas, palcos imersivos e visuais vivos.",
+      "ctaProjects": "+ ver os meus projetos",
+      "ctaAbout": "+ saber mais sobre mim"
     }
   },
   "work": {


### PR DESCRIPTION
## Summary
- replace the home hero with a centered, lowercase Sharlee-inspired layout and CTAs
- refresh the global gradient/typographic styling to match the neon pastel look
- update Three.js palette positions and locale strings for the new copy

## Testing
- npm run verify:three

------
https://chatgpt.com/codex/tasks/task_e_68dc540b1744832fbaaf009c23fae6bf