### PR TITLE
feat: refresh navigation styling

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -14,7 +14,7 @@ export default function LanguageSwitcher() {
   const currentLanguage = (i18n.resolvedLanguage || i18n.language || "pt").split("-")[0];
 
   return (
-    <div className="flex items-center gap-1 rounded-full border border-fg/15 bg-bg/80 px-1.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-fg shadow-soft backdrop-blur">
+    <div className="flex items-center gap-1.5 rounded-full border border-fg/12 bg-white/70 px-2 py-1 text-[0.6rem] font-medium uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur">
       {LANGUAGES.map(({ code, label }) => {
         const isActive = currentLanguage === code;
         return (
@@ -27,10 +27,10 @@ export default function LanguageSwitcher() {
               }
             }}
             className={clsx(
-              "rounded-full px-3 py-1 transition",
+              "rounded-full px-2.5 py-1 transition duration-300 ease-out",
               isActive
                 ? "bg-fg text-bg shadow-soft"
-                : "text-fg/70 hover:text-fg"
+                : "text-fg/60 hover:text-fg"
             )}
             aria-pressed={isActive}
             aria-label={t("languageSwitcher.ariaLabel", { label })}

--- a/components/MenuToggleIcon.tsx
+++ b/components/MenuToggleIcon.tsx
@@ -6,11 +6,6 @@ type MenuToggleIconProps = {
   isOpen: boolean;
 } & Omit<SVGMotionProps<SVGSVGElement>, "animate" | "initial">;
 
-const transition = {
-  duration: 0.4,
-  ease: [0.4, 0, 0.2, 1] as const,
-};
-
 export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggleIconProps) {
   const composedClassName = ["relative", className].filter(Boolean).join(" ");
   const state = isOpen ? "open" : "closed";
@@ -25,18 +20,34 @@ export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggl
       animate={state}
       {...rest}
     >
+      <motion.circle
+        cx={12}
+        cy={12}
+        r={9.5}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={0.5}
+        strokeOpacity={0.22}
+        variants={{
+          closed: { scale: 1, opacity: 0.55 },
+          open: { scale: 1.05, opacity: 0.35 },
+        }}
+        transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+      />
       <motion.path
         variants={{
           closed: {
-            d: "M5 7.5h14",
+            d: "M5.5 8c1.9-.8 4.1-1.2 6.5-1.2s4.6.4 6.5 1.2",
+            rotate: 0,
           },
           open: {
             d: "M6.2 6.2l11.6 11.6",
+            rotate: 2,
           },
         }}
-        transition={transition}
+        transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
         stroke="currentColor"
-        strokeWidth={1.8}
+        strokeWidth={1.6}
         strokeLinecap="round"
       />
       <motion.path
@@ -50,23 +61,25 @@ export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggl
             d: "M12 12h0",
           },
         }}
-        transition={transition}
+        transition={{ duration: 0.35, ease: [0.4, 0, 0.2, 1] }}
         stroke="currentColor"
-        strokeWidth={1.8}
+        strokeWidth={1.5}
         strokeLinecap="round"
       />
       <motion.path
         variants={{
           closed: {
-            d: "M5 16.5h14",
+            d: "M18.5 16c-1.9.8-4.1 1.2-6.5 1.2s-4.6-.4-6.5-1.2",
+            rotate: 0,
           },
           open: {
             d: "M17.8 6.2L6.2 17.8",
+            rotate: -2,
           },
         }}
-        transition={transition}
+        transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
         stroke="currentColor"
-        strokeWidth={1.8}
+        strokeWidth={1.6}
         strokeLinecap="round"
       />
     </motion.svg>

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -19,6 +19,12 @@ import {
   type ThreeAppHandle,
   type VariantName,
 } from "./three/types";
+import {
+  BehanceIcon,
+  DribbbleIcon,
+  InstagramIcon,
+  LinkedInIcon,
+} from "./icons/SocialIcons";
 
 type NavigationLink = {
   name: string;
@@ -166,18 +172,19 @@ export default function NavOverlay({
           transition={{ duration: 0.25, ease: "easeInOut" }}
         >
           <motion.div
-            className="absolute inset-0 bg-gradient-to-br from-brand-900 via-accent2-900/90 to-accent3-900"
+            className="absolute inset-0 bg-gradient-to-br from-[#F9F5FF] via-[#FDF8F4] to-[#F0FBFF]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.35, ease: "easeInOut" }}
           />
           <div
-            className="pointer-events-none absolute inset-0 opacity-35 mix-blend-screen"
+            className="pointer-events-none absolute inset-0"
             aria-hidden
           >
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,214,255,0.35)_0%,rgba(193,235,255,0.18)_40%,transparent_75%)]" />
-            <div className="absolute left-1/2 top-1/2 h-[min(60vh,32rem)] w-[min(60vh,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[conic-gradient(from_90deg_at_50%_50%,rgba(255,240,254,0.55)_0deg,rgba(206,235,255,0.35)_140deg,rgba(255,214,240,0.4)_260deg,rgba(255,240,254,0.55)_360deg)] blur-3xl" />
+            <div className="absolute -left-32 top-10 h-72 w-72 rounded-full bg-[radial-gradient(circle,#F7E7FF_0%,rgba(255,246,233,0)_70%)] blur-3xl" />
+            <div className="absolute bottom-0 left-1/2 h-[22rem] w-[22rem] -translate-x-1/2 translate-y-1/3 rounded-full bg-[radial-gradient(circle,#E8FFF6_0%,rgba(232,255,246,0)_70%)] blur-3xl" />
+            <div className="absolute -right-16 top-1/4 h-80 w-80 rounded-full bg-[radial-gradient(circle,#E2F1FF_0%,rgba(226,241,255,0)_70%)] blur-3xl" />
           </div>
 
           <motion.div
@@ -187,7 +194,7 @@ export default function NavOverlay({
             exit={{ opacity: 0, y: 24 }}
             transition={{ duration: 0.35, ease: "easeOut" }}
           >
-            <header className="flex items-center justify-between px-6 pt-10 text-xs font-medium uppercase tracking-[0.42em] text-fg/60 md:px-12">
+            <header className="flex items-center justify-between px-6 pt-10 text-[0.7rem] font-medium uppercase tracking-[0.42em] text-fg/60 md:px-12">
               <motion.span
                 id="main-navigation-title"
                 initial={{ y: -8, opacity: 0 }}
@@ -199,7 +206,7 @@ export default function NavOverlay({
               <motion.button
                 type="button"
                 onClick={onClose}
-                className="flex items-center gap-2 rounded-full bg-fg/10 px-4 py-2 text-[0.7rem] font-medium uppercase tracking-[0.28em] text-fg transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                className="rounded-full border border-fg/10 bg-white/70 px-4 py-2 text-[0.65rem] uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur transition hover:border-fg/30 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
                 initial={{ y: -8, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: 0.15, duration: 0.3 }}
@@ -208,17 +215,17 @@ export default function NavOverlay({
               </motion.button>
             </header>
 
-            <div className="flex flex-1 flex-col justify-end gap-16 px-6 pb-12 text-left md:flex-row md:items-end md:justify-between md:px-12 md:pb-16">
+            <div className="relative flex flex-1 items-center justify-center px-6 pb-20 pt-10 md:px-12 md:pb-24">
               <nav aria-label={t("navbar.menu")} className="w-full md:w-auto">
                 <motion.ul
                   ref={navListRef}
-                  className="flex flex-col gap-6 text-4xl font-medium uppercase tracking-[0.26em] text-fg sm:text-5xl md:text-[clamp(3rem,6vw,4.5rem)]"
+                  className="flex flex-col items-center gap-6 text-center text-4xl font-light uppercase tracking-[0.28em] text-fg/90 sm:text-5xl md:text-[clamp(3.25rem,6vw,4.75rem)]"
                   initial="hidden"
                   animate="visible"
                   variants={{
                     hidden: {},
                     visible: {
-                      transition: { staggerChildren: 0.08, delayChildren: 0.15 },
+                      transition: { staggerChildren: 0.08, delayChildren: 0.18 },
                     },
                   }}
                   onMouseLeave={restoreInitialVariant}
@@ -227,7 +234,7 @@ export default function NavOverlay({
                     <motion.li
                       key={href}
                       variants={{
-                        hidden: { opacity: 0, y: 24 },
+                        hidden: { opacity: 0, y: 20 },
                         visible: { opacity: 1, y: 0 },
                       }}
                     >
@@ -238,12 +245,11 @@ export default function NavOverlay({
                         onMouseEnter={handleLinkFocus(name as VariantName)}
                         onFocus={handleLinkFocus(name as VariantName)}
                         onBlur={handleLinkBlur}
-                        className="group flex items-center gap-6 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
+                        className="group relative inline-flex items-center justify-center px-2 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
                       >
-                        <span className="text-sm font-medium tracking-[0.38em] text-fg/45">0{index + 1}</span>
-                        <span className="relative">
-                          <span className="block transition duration-300 ease-out group-hover:-translate-y-1">{name}</span>
-                          <span className="absolute inset-x-0 bottom-0 h-[3px] origin-left scale-x-0 bg-fg/80 transition-transform duration-300 ease-out group-hover:scale-x-100" />
+                        <span className="relative inline-block overflow-hidden">
+                          <span className="block translate-y-0 transition-transform duration-300 ease-out group-hover:-translate-y-1">{name}</span>
+                          <span className="absolute inset-x-0 bottom-0 h-[2px] origin-center scale-x-0 bg-fg/70 transition-transform duration-300 ease-out group-hover:scale-x-100" />
                         </span>
                       </Link>
                     </motion.li>
@@ -252,28 +258,31 @@ export default function NavOverlay({
               </nav>
 
               <motion.div
-                className="flex w-full flex-col gap-8 text-sm font-medium uppercase tracking-[0.32em] text-fg/60 md:w-64"
-                initial={{ opacity: 0, y: 24 }}
+                className="pointer-events-auto absolute bottom-10 right-8 hidden flex-col items-end gap-3 text-[0.65rem] uppercase tracking-[0.38em] text-fg/60 md:flex"
+                initial={{ opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.35, duration: 0.4 }}
+                transition={{ delay: 0.45, duration: 0.35 }}
               >
-                <div className="flex flex-col gap-2 text-xs tracking-[0.4em] text-fg/40">
-                  <span>{t("navOverlay.socialHeading")}</span>
-                  <div className="h-px w-16 bg-fg/20" />
-                </div>
-                <div className="flex flex-col gap-2 text-xs font-medium tracking-[0.4em] text-fg/40">
-                  {socialLinks.map(({ label, href }) => (
-                    <Link
-                      key={label}
-                      href={href}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      prefetch={false}
-                      className="rounded-full bg-fg/10 px-5 py-2 transition hover:bg-fg/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-                    >
-                      {label}
-                    </Link>
-                  ))}
+                <span className="text-fg/45">{t("navOverlay.socialHeading")}</span>
+                <div className="flex flex-col gap-2 text-fg/70">
+                  {socialLinks.map(({ label, href }) => {
+                    const IconComponent = socialIcons[label as keyof typeof socialIcons] ?? LinkedInIcon;
+                    return (
+                      <Link
+                        key={label}
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        prefetch={false}
+                        className="group flex items-center gap-3 rounded-full border border-fg/10 bg-white/70 px-4 py-1.5 text-[0.6rem] tracking-[0.32em] text-inherit shadow-soft backdrop-blur transition hover:border-fg/30 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                      >
+                        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-fg/10 text-fg/80 transition duration-300 ease-out group-hover:bg-fg group-hover:text-bg">
+                          <IconComponent className="h-3.5 w-3.5" />
+                        </span>
+                        <span>{label}</span>
+                      </Link>
+                    );
+                  })}
                 </div>
               </motion.div>
             </div>
@@ -283,3 +292,10 @@ export default function NavOverlay({
     </AnimatePresence>
   );
 }
+
+const socialIcons = {
+  LinkedIn: LinkedInIcon,
+  Behance: BehanceIcon,
+  Dribbble: DribbbleIcon,
+  Instagram: InstagramIcon,
+} as const;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -97,19 +97,21 @@ export default function Navbar() {
 
   return (
     <>
-      <div className="fixed inset-x-0 top-6 z-50 px-6">
-        <div className="flex items-center justify-between gap-6">
+      <div className="fixed inset-x-0 top-5 z-50 px-6 md:px-10">
+        <div className="flex items-start justify-between gap-6">
           <Link
             href="/"
-            className="flex items-center gap-2 rounded-full bg-bg/70 px-4 py-2 text-sm font-semibold uppercase tracking-[0.32em] text-fg/80 transition hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+            className="group inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+            aria-label="Sharlee Studio"
           >
-            <span className="text-fg">DD</span>
-            <span className="hidden text-xs sm:inline">Duartois Design</span>
+            <SharleeMonogram className="h-12 w-12 text-fg transition duration-300 ease-out group-hover:scale-[1.02]" />
           </Link>
 
-          <div className="flex items-center gap-3">
-            <LanguageSwitcher />
-            <ThemeToggle />
+          <div className="flex flex-col items-end gap-3">
+            <div className="flex items-center gap-2 text-right">
+              <LanguageSwitcher />
+              <ThemeToggle />
+            </div>
 
             <button
               ref={triggerRef}
@@ -118,14 +120,16 @@ export default function Navbar() {
               aria-haspopup="dialog"
               aria-expanded={isOpen}
               aria-controls="main-navigation-overlay"
-              className="group relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-fg/15 bg-bg/80 text-fg shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] backdrop-blur transition-colors duration-300 hover:border-fg/40 hover:bg-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+              className="group relative flex items-center gap-3 rounded-full border border-fg/15 bg-white/70 px-4 py-2 text-sm font-medium uppercase tracking-[0.32em] text-fg/80 shadow-[0_10px_30px_-18px_rgba(18,23,35,0.35)] backdrop-blur transition duration-300 ease-out hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
             >
-              <span className="sr-only">{isOpen ? t("navbar.close") : t("navbar.open")}</span>
-              <MenuToggleIcon
-                aria-hidden="true"
-                isOpen={isOpen}
-                className="h-6 w-6 text-fg transition-colors duration-300 group-hover:text-fg group-focus-visible:text-fg"
-              />
+              <span>{isOpen ? t("navbar.close") : t("navbar.open")}</span>
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 transition duration-300 ease-out group-hover:bg-fg/20">
+                <MenuToggleIcon
+                  aria-hidden="true"
+                  isOpen={isOpen}
+                  className="h-5 w-5 text-fg transition duration-300 ease-out"
+                />
+              </span>
             </button>
           </div>
         </div>
@@ -140,5 +144,68 @@ export default function Navbar() {
         overlayRef={overlayRef}
       />
     </>
+  );
+}
+
+function SharleeMonogram({ className }: { className?: string }) {
+  return (
+    <span className={className}>
+      <svg
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-full w-full"
+      >
+        <defs>
+          <linearGradient id="sharleeMonogramBg" x1="12" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="#F1E8FF" />
+            <stop offset="0.52" stopColor="#FCE5F6" />
+            <stop offset="1" stopColor="#E9F7FF" />
+          </linearGradient>
+          <linearGradient id="sharleeMonogramStroke" x1="20" y1="12" x2="44" y2="52" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="#6741D9" />
+            <stop offset="1" stopColor="#0FA3B1" />
+          </linearGradient>
+        </defs>
+        <rect
+          x="2"
+          y="2"
+          width="60"
+          height="60"
+          rx="18"
+          fill="url(#sharleeMonogramBg)"
+        />
+        <rect
+          x="2"
+          y="2"
+          width="60"
+          height="60"
+          rx="18"
+          stroke="rgba(27, 30, 36, 0.08)"
+          strokeWidth="2"
+        />
+        <path
+          d="M42 16h-9.5a8.5 8.5 0 0 0 0 17h6a9.5 9.5 0 1 1 0 19h-9.5a9.5 9.5 0 0 1-9.5-9.5"
+          stroke="url(#sharleeMonogramStroke)"
+          strokeWidth="5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle
+          cx="32"
+          cy="17"
+          r="3"
+          fill="#6741D9"
+          fillOpacity="0.9"
+        />
+        <circle
+          cx="32"
+          cy="47"
+          r="3"
+          fill="#0FA3B1"
+          fillOpacity="0.85"
+        />
+      </svg>
+    </span>
   );
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -24,14 +24,11 @@ export default function ThemeToggle() {
       type="button"
       onClick={toggle}
       className={clsx(
-        "group relative flex h-11 w-11 items-center justify-center rounded-full border bg-bg/90 text-fg shadow-soft transition-all duration-300 ease-pleasant",
-        "hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        "group relative flex h-11 w-11 items-center justify-center rounded-full border border-fg/12 bg-white/70 text-fg/80 shadow-soft backdrop-blur transition-all duration-300 ease-pleasant",
+        "hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
         theme === "dark"
-          ? "border-accent3-700/60 text-accent3-100 hover:border-accent3-400/80 hover:bg-accent3-900/40 focus-visible:outline-accent3-300/60"
-          : "border-brand-200/80 text-brand-700 hover:border-brand-400 hover:bg-brand-100/60 focus-visible:outline-brand-400/70",
-        theme === "dark"
-          ? "ring-1 ring-accent3-500/40"
-          : "ring-1 ring-brand-400/50",
+          ? "hover:border-accent3-400/70 hover:text-accent3-200"
+          : "hover:border-brand-400/70 hover:text-brand-600",
       )}
       aria-label={t("themeToggle.ariaLabel", { theme: nextThemeLabel })}
       aria-pressed={theme === "dark"}

--- a/components/icons/SocialIcons.tsx
+++ b/components/icons/SocialIcons.tsx
@@ -1,0 +1,69 @@
+import type { SVGProps } from "react";
+
+function createIcon(Component: (props: SVGProps<SVGSVGElement>) => JSX.Element) {
+  return function Icon(props: SVGProps<SVGSVGElement>) {
+    const { width = 16, height = 16, ...rest } = props;
+    return <Component width={width} height={height} {...rest} />;
+  };
+}
+
+export const LinkedInIcon = createIcon(function LinkedInIcon(
+  props: SVGProps<SVGSVGElement>,
+) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} {...props}>
+      <rect x={3} y={3} width={18} height={18} rx={4} stroke="currentColor" />
+      <path d="M8.5 10.25v6.5" strokeLinecap="round" />
+      <path d="M8.5 7.35h.01" strokeLinecap="round" />
+      <path d="M12.75 16.75v-3.6a2.1 2.1 0 0 1 4.2 0v3.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+});
+
+export const BehanceIcon = createIcon(function BehanceIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} {...props}>
+      <rect x={3} y={3} width={18} height={18} rx={4} stroke="currentColor" />
+      <path
+        d="M8 7.75h2.25a2.5 2.5 0 0 1 0 5H8v-5Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 12.75h2.35a2.65 2.65 0 1 1-2.35 2.65V7.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M13.75 10.4h4.1" strokeLinecap="round" />
+      <path
+        d="M13.5 13.1a2.6 2.6 0 0 1 5.18.42v.3c0 1.67-1 2.9-2.6 2.9-1.42 0-2.58-.94-2.58-2.56"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+});
+
+export const DribbbleIcon = createIcon(function DribbbleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} {...props}>
+      <rect x={3} y={3} width={18} height={18} rx={4} stroke="currentColor" />
+      <circle cx={12} cy={12} r={5} stroke="currentColor" />
+      <path d="M7.8 11.1c1.62-.15 3.34-.12 5.05.1" strokeLinecap="round" />
+      <path d="M10.25 7.75c1.55 1.85 2.7 4.2 3.38 6.78" strokeLinecap="round" />
+      <path d="M9.5 16.1c.55-2.16 1.76-3.7 4.7-3.94" strokeLinecap="round" />
+    </svg>
+  );
+});
+
+export const InstagramIcon = createIcon(function InstagramIcon(
+  props: SVGProps<SVGSVGElement>,
+) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} {...props}>
+      <rect x={3} y={3} width={18} height={18} rx={5} stroke="currentColor" />
+      <circle cx={12} cy={12} r={3.8} stroke="currentColor" />
+      <path d="M16.2 7.8h.01" strokeLinecap="round" />
+    </svg>
+  );
+});


### PR DESCRIPTION
## Summary
- swap the navbar branding for a Sharlee-inspired monogram and realign the language/theme controls with an updated menu trigger
- restyle the navigation overlay with a bright gradient, centered typography, and a social link column that uses fresh icons
- refresh supporting toggle components and add reusable social network glyphs to match the new visual language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc56261e5c832fa56686da6620588c