### PR TITLE
Refactor navigation header controls

### DIFF
--- a/components/NavHeaderContent.tsx
+++ b/components/NavHeaderContent.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import clsx from "classnames";
+import Link from "next/link";
+import { type ButtonHTMLAttributes, type RefObject } from "react";
+
+import LanguageSwitcher from "./LanguageSwitcher";
+import MenuToggleIcon from "./MenuToggleIcon";
+import ThemeToggle from "./ThemeToggle";
+import SharleeMonogramIcon from "./icons/SharleeMonogram";
+import SharleeMonogram from "./SharleeMonogram";
+
+type Variant = "default" | "overlay";
+
+type NavHeaderContentProps = {
+  variant?: Variant;
+  isOpen: boolean;
+  onToggle: () => void;
+  triggerRef?: RefObject<HTMLButtonElement>;
+  labels: {
+    open: string;
+    close: string;
+  };
+  brandHref?: string;
+  onBrandClick?: () => void;
+  buttonProps?: Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">;
+};
+
+export default function NavHeaderContent({
+  variant = "default",
+  isOpen,
+  onToggle,
+  triggerRef,
+  labels,
+  brandHref = "/",
+  onBrandClick,
+  buttonProps,
+}: NavHeaderContentProps) {
+  const variantStyles = styles[variant];
+  const { className: buttonClassName, ...restButtonProps } = buttonProps ?? {};
+
+  return (
+    <div className={variantStyles.container}>
+      <Link
+        href={brandHref}
+        aria-label="Sharlee Studio"
+        onClick={onBrandClick}
+        className={variantStyles.brandLink}
+      >
+        {variant === "overlay" ? (
+          <span className={variantStyles.brandInner}>
+            <SharleeMonogramIcon aria-hidden />
+          </span>
+        ) : (
+          <>
+            <SharleeMonogramIcon
+              className="text-fg transition duration-300 ease-out group-hover:scale-[1.02]"
+              aria-hidden
+            />
+            <SharleeMonogram className="h-12 w-12 text-fg transition duration-300 ease-out group-hover:scale-[1.02]" />
+          </>
+        )}
+      </Link>
+
+      <div className={variantStyles.controlsContainer}>
+        <div className={variantStyles.switcherContainer}>
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
+
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={onToggle}
+          {...restButtonProps}
+          className={clsx(variantStyles.button, buttonClassName)}
+        >
+          <span>{isOpen ? labels.close : labels.open}</span>
+          <span className={variantStyles.buttonIconWrapper}>
+            <MenuToggleIcon
+              aria-hidden="true"
+              isOpen={isOpen}
+              className={variantStyles.buttonIcon}
+            />
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<Variant, {
+  container: string;
+  brandLink: string;
+  brandInner?: string;
+  controlsContainer: string;
+  switcherContainer: string;
+  button: string;
+  buttonIconWrapper: string;
+  buttonIcon: string;
+}> = {
+  default: {
+    container: "flex items-start justify-between gap-6",
+    brandLink:
+      "group inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+    controlsContainer: "flex flex-col items-end gap-3",
+    switcherContainer: "flex items-center gap-2 text-right",
+    button:
+      "group relative flex items-center gap-3 rounded-full border border-fg/15 bg-white/70 px-4 py-2 text-sm font-medium uppercase tracking-[0.32em] text-fg/80 shadow-[0_10px_30px_-18px_rgba(18,23,35,0.35)] backdrop-blur transition duration-300 ease-out hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+    buttonIconWrapper:
+      "flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 transition duration-300 ease-out group-hover:bg-fg/20",
+    buttonIcon: "h-5 w-5 text-fg transition duration-300 ease-out",
+  },
+  overlay: {
+    container: "flex items-start justify-between gap-6",
+    brandLink:
+      "pointer-events-auto inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-4 py-2 text-[0.65rem] uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur transition hover:border-fg/30 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+    brandInner:
+      "inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+    controlsContainer:
+      "pointer-events-auto flex flex-col items-end gap-3 text-[0.65rem] uppercase tracking-[0.32em] text-fg/60",
+    switcherContainer: "flex items-center gap-2",
+    button:
+      "group flex items-center gap-3 rounded-full border border-fg/12 bg-white/70 px-6 py-2 text-[0.65rem] font-medium tracking-[0.28em] text-fg/80 shadow-soft backdrop-blur transition hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+    buttonIconWrapper:
+      "flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 text-fg transition duration-300 ease-out group-hover:bg-fg group-hover:text-bg",
+    buttonIcon: "h-5 w-5",
+  },
+};

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -12,9 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
 
-import LanguageSwitcher from "./LanguageSwitcher";
-import MenuToggleIcon from "./MenuToggleIcon";
-import ThemeToggle from "./ThemeToggle";
+import NavHeaderContent from "./NavHeaderContent";
 import {
   getDefaultPalette,
   type GradientPalette,
@@ -23,7 +21,6 @@ import {
   type VariantName,
 } from "./three/types";
 
-import SharleeMonogramIcon from "./icons/SharleeMonogram";
 import ArrowLaunchIcon from "./icons/ArrowLaunchIcon";
 
 import {
@@ -223,34 +220,16 @@ export default function NavOverlay({
                 initial={{ y: -8, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: 0.15, duration: 0.3 }}
+                className="w-full"
               >
-                <Link
-                  href="/"
-                  aria-label="Sharlee Studio"
-                  onClick={onClose}
-                  className="pointer-events-auto inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-4 py-2 text-[0.65rem] uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur transition hover:border-fg/30 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-                >
-                  <span className="inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg">
-                    <SharleeMonogramIcon aria-hidden />
-                  </span>
-                </Link>
+                <NavHeaderContent
+                  variant="overlay"
+                  isOpen={isOpen}
+                  onToggle={onClose}
+                  labels={{ open: t("navbar.open"), close: t("navbar.close") }}
+                  onBrandClick={onClose}
+                />
               </motion.div>
-              <div className="pointer-events-auto flex flex-col items-end gap-3 text-[0.65rem] uppercase tracking-[0.32em] text-fg/60">
-                <div className="flex items-center gap-2">
-                  <LanguageSwitcher />
-                  <ThemeToggle />
-                </div>
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="group flex items-center gap-3 rounded-full border border-fg/12 bg-white/70 px-6 py-2 text-[0.65rem] font-medium tracking-[0.28em] text-fg/80 shadow-soft backdrop-blur transition hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-                >
-                  <span>{t("navbar.close")}</span>
-                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 text-fg transition duration-300 ease-out group-hover:bg-fg group-hover:text-bg">
-                    <MenuToggleIcon isOpen className="h-5 w-5" aria-hidden />
-                  </span>
-                </button>
-              </div>
             </motion.header>
 
             <div className="relative flex flex-1 items-center justify-center px-6 pb-24 pt-12 md:px-12">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,15 +1,11 @@
 "use client";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
 
-import LanguageSwitcher from "./LanguageSwitcher";
-import MenuToggleIcon from "./MenuToggleIcon";
+import NavHeaderContent from "./NavHeaderContent";
 import NavOverlay from "./NavOverlay";
-import ThemeToggle from "./ThemeToggle";
-import SharleeMonogramIcon from "./icons/SharleeMonogram";
 
 const navigationLinks = [
   { name: "home", href: "/" },
@@ -99,45 +95,17 @@ export default function Navbar() {
   return (
     <>
       <div className="fixed inset-x-0 top-5 z-50 px-6 md:px-10">
-        <div className="flex items-start justify-between gap-6">
-          <Link
-            href="/"
-            className="group inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-            aria-label="Sharlee Studio"
-          >
-
-            <SharleeMonogramIcon className="text-fg transition duration-300 ease-out group-hover:scale-[1.02]" aria-hidden />
-
-            <SharleeMonogram className="h-12 w-12 text-fg transition duration-300 ease-out group-hover:scale-[1.02]" />
-
-          </Link>
-
-          <div className="flex flex-col items-end gap-3">
-            <div className="flex items-center gap-2 text-right">
-              <LanguageSwitcher />
-              <ThemeToggle />
-            </div>
-
-            <button
-              ref={triggerRef}
-              type="button"
-              onClick={() => setIsOpen((open) => !open)}
-              aria-haspopup="dialog"
-              aria-expanded={isOpen}
-              aria-controls="main-navigation-overlay"
-              className="group relative flex items-center gap-3 rounded-full border border-fg/15 bg-white/70 px-4 py-2 text-sm font-medium uppercase tracking-[0.32em] text-fg/80 shadow-[0_10px_30px_-18px_rgba(18,23,35,0.35)] backdrop-blur transition duration-300 ease-out hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
-            >
-              <span>{isOpen ? t("navbar.close") : t("navbar.open")}</span>
-              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 transition duration-300 ease-out group-hover:bg-fg/20">
-                <MenuToggleIcon
-                  aria-hidden="true"
-                  isOpen={isOpen}
-                  className="h-5 w-5 text-fg transition duration-300 ease-out"
-                />
-              </span>
-            </button>
-          </div>
-        </div>
+        <NavHeaderContent
+          isOpen={isOpen}
+          onToggle={() => setIsOpen((open) => !open)}
+          triggerRef={triggerRef}
+          labels={{ open: t("navbar.open"), close: t("navbar.close") }}
+          buttonProps={{
+            "aria-haspopup": "dialog",
+            "aria-expanded": isOpen,
+            "aria-controls": "main-navigation-overlay",
+          }}
+        />
       </div>
 
       <NavOverlay
@@ -149,68 +117,5 @@ export default function Navbar() {
         overlayRef={overlayRef}
       />
     </>
-  );
-}
-
-function SharleeMonogram({ className }: { className?: string }) {
-  return (
-    <span className={className}>
-      <svg
-        viewBox="0 0 64 64"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className="h-full w-full"
-      >
-        <defs>
-          <linearGradient id="sharleeMonogramBg" x1="12" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stopColor="#F1E8FF" />
-            <stop offset="0.52" stopColor="#FCE5F6" />
-            <stop offset="1" stopColor="#E9F7FF" />
-          </linearGradient>
-          <linearGradient id="sharleeMonogramStroke" x1="20" y1="12" x2="44" y2="52" gradientUnits="userSpaceOnUse">
-            <stop offset="0" stopColor="#6741D9" />
-            <stop offset="1" stopColor="#0FA3B1" />
-          </linearGradient>
-        </defs>
-        <rect
-          x="2"
-          y="2"
-          width="60"
-          height="60"
-          rx="18"
-          fill="url(#sharleeMonogramBg)"
-        />
-        <rect
-          x="2"
-          y="2"
-          width="60"
-          height="60"
-          rx="18"
-          stroke="rgba(27, 30, 36, 0.08)"
-          strokeWidth="2"
-        />
-        <path
-          d="M42 16h-9.5a8.5 8.5 0 0 0 0 17h6a9.5 9.5 0 1 1 0 19h-9.5a9.5 9.5 0 0 1-9.5-9.5"
-          stroke="url(#sharleeMonogramStroke)"
-          strokeWidth="5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <circle
-          cx="32"
-          cy="17"
-          r="3"
-          fill="#6741D9"
-          fillOpacity="0.9"
-        />
-        <circle
-          cx="32"
-          cy="47"
-          r="3"
-          fill="#0FA3B1"
-          fillOpacity="0.85"
-        />
-      </svg>
-    </span>
   );
 }

--- a/components/SharleeMonogram.tsx
+++ b/components/SharleeMonogram.tsx
@@ -1,0 +1,31 @@
+import { type SVGProps } from "react";
+
+export default function SharleeMonogram(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <defs>
+        <linearGradient id="sharleeMonogramBg" x1="12" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#F1E8FF" />
+          <stop offset="0.52" stopColor="#FCE5F6" />
+          <stop offset="1" stopColor="#E9F7FF" />
+        </linearGradient>
+        <linearGradient id="sharleeMonogramStroke" x1="20" y1="12" x2="44" y2="52" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#6741D9" />
+          <stop offset="1" stopColor="#0FA3B1" />
+        </linearGradient>
+      </defs>
+      <rect x="2" y="2" width="60" height="60" rx="18" fill="url(#sharleeMonogramBg)" />
+      <rect x="2" y="2" width="60" height="60" rx="18" stroke="rgba(27, 30, 36, 0.08)" strokeWidth="2" />
+      <path
+        d="M42 16h-9.5a8.5 8.5 0 0 0 0 17h6a9.5 9.5 0 1 1 0 19h-9.5a9.5 9.5 0 0 1-9.5-9.5"
+        stroke="url(#sharleeMonogramStroke)"
+        strokeWidth="5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="32" cy="17" r="3" fill="#6741D9" fillOpacity="0.9" />
+      <circle cx="32" cy="47" r="3" fill="#0FA3B1" fillOpacity="0.85" />
+      <circle cx="32" cy="32" r="30" stroke="rgba(27, 30, 36, 0.08)" strokeWidth="2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the shared navigation header controls into a reusable component
- reuse the shared header component in both the navbar and overlay to remove duplication
- move the SVG monogram into its own component for reuse and keep focus handling intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6b10a494832fa7acd2fb3b96acba