### PR TITLE
Delay CanvasRoot rendering until preloader completes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 import type { ReactNode } from "react";
 import classNames from "classnames";
 import AppShell from "@/components/AppShell";
-import CanvasRoot from "@/components/three/CanvasRoot";
 import ThemeScript from "./theme/ThemeScript";
 import { ThemeProvider } from "./theme/ThemeContext";
 import { neueMontreal } from "./fonts/fonts";
@@ -21,7 +20,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         )}
       >
         <ThemeProvider>
-          <CanvasRoot />
           <AppShell>{children}</AppShell>
         </ThemeProvider>
       </body>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useCallback, useState } from "react";
 import Preloader from "./Preloader";
+import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
   children: ReactNode;
@@ -17,9 +18,12 @@ export default function AppShell({ children }: AppShellProps) {
   return (
     <>
       {!isReady && <Preloader onComplete={handleComplete} />}
+      {isReady ? <CanvasRoot /> : null}
       <div
         className={`transition-opacity duration-700 ${
-          isReady ? "opacity-100" : "pointer-events-none opacity-0"
+          isReady
+            ? "visible opacity-100"
+            : "pointer-events-none opacity-0 invisible"
         }`}
         aria-hidden={!isReady}
         aria-busy={!isReady}


### PR DESCRIPTION
## Summary
- move `CanvasRoot` into the application shell so it renders only after the preloader completes
- keep shell content invisible until the ready state to avoid leaking visuals beneath the preloader overlay

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc6cd66434832fb6651ee82885114d