### PR TITLE
Keep canvas hidden during preload

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 import type { ReactNode } from "react";
 import classNames from "classnames";
 import AppShell from "@/components/AppShell";
-import CanvasRoot from "@/components/three/CanvasRoot";
 import ThemeScript from "./theme/ThemeScript";
 import { ThemeProvider } from "./theme/ThemeContext";
 import { neueMontreal } from "./fonts/fonts";
@@ -21,7 +20,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         )}
       >
         <ThemeProvider>
-          <CanvasRoot />
           <AppShell>{children}</AppShell>
         </ThemeProvider>
       </body>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useCallback, useState } from "react";
 import Preloader from "./Preloader";
+import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
   children: ReactNode;
@@ -17,9 +18,12 @@ export default function AppShell({ children }: AppShellProps) {
   return (
     <>
       {!isReady && <Preloader onComplete={handleComplete} />}
+      <CanvasRoot isReady={isReady} />
       <div
         className={`transition-opacity duration-700 ${
-          isReady ? "opacity-100" : "pointer-events-none opacity-0"
+          isReady
+            ? "visible opacity-100"
+            : "pointer-events-none opacity-0 invisible"
         }`}
         aria-hidden={!isReady}
         aria-busy={!isReady}

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import classNames from "classnames";
 import { useEffect, useState } from "react";
 
 import CoreCanvas from "./CoreCanvas";
 
-export default function CanvasRoot() {
+interface CanvasRootProps {
+  isReady: boolean;
+}
+
+export default function CanvasRoot({ isReady }: CanvasRootProps) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -13,8 +18,11 @@ export default function CanvasRoot() {
 
   return (
     <div
-      className="pointer-events-none fixed inset-0 -z-5 overflow-visible"
-      aria-hidden
+      className={classNames(
+        "pointer-events-none fixed inset-0 -z-5 overflow-visible transition-opacity duration-700",
+        isReady ? "opacity-100" : "opacity-0",
+      )}
+      aria-hidden={!isReady}
     >
       {mounted ? <CoreCanvas /> : null}
     </div>


### PR DESCRIPTION
## Summary
- keep the `CanvasRoot` mounted throughout the preload flow while hiding it until the ready state
- fade in the canvas once the preloader finishes to avoid leaking visuals while preserving prerendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6cd66434832fb6651ee82885114d