### PR TITLE
Refine navigation header layout

### DIFF
--- a/components/NavHeaderContent.tsx
+++ b/components/NavHeaderContent.tsx
@@ -7,8 +7,6 @@ import { type ButtonHTMLAttributes, type RefObject } from "react";
 import LanguageSwitcher from "./LanguageSwitcher";
 import MenuToggleIcon from "./MenuToggleIcon";
 import ThemeToggle from "./ThemeToggle";
-import SharleeMonogramIcon from "./icons/SharleeMonogram";
-import SharleeMonogram from "./SharleeMonogram";
 
 type Variant = "default" | "overlay";
 
@@ -47,19 +45,8 @@ export default function NavHeaderContent({
         onClick={onBrandClick}
         className={variantStyles.brandLink}
       >
-        {variant === "overlay" ? (
-          <span className={variantStyles.brandInner}>
-            <SharleeMonogramIcon aria-hidden />
-          </span>
-        ) : (
-          <>
-            <SharleeMonogramIcon
-              className="text-fg transition duration-300 ease-out group-hover:scale-[1.02]"
-              aria-hidden
-            />
-            <SharleeMonogram className="h-12 w-12 text-fg transition duration-300 ease-out group-hover:scale-[1.02]" />
-          </>
-        )}
+        <span className={variantStyles.brandPrefix}>Duartois/</span>
+        <span className={variantStyles.brandSuffix}>Matheus Duarte</span>
       </Link>
 
       <div className={variantStyles.controlsContainer}>
@@ -89,41 +76,46 @@ export default function NavHeaderContent({
   );
 }
 
-const styles: Record<Variant, {
-  container: string;
-  brandLink: string;
-  brandInner?: string;
-  controlsContainer: string;
-  switcherContainer: string;
-  button: string;
-  buttonIconWrapper: string;
-  buttonIcon: string;
-}> = {
+const styles: Record<
+  Variant,
+  {
+    container: string;
+    brandLink: string;
+    brandPrefix: string;
+    brandSuffix: string;
+    controlsContainer: string;
+    switcherContainer: string;
+    button: string;
+    buttonIconWrapper: string;
+    buttonIcon: string;
+  }
+> = {
   default: {
-    container: "flex items-start justify-between gap-6",
+    container: "flex items-center justify-between gap-6",
     brandLink:
-      "group inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
-    controlsContainer: "flex flex-col items-end gap-3",
-    switcherContainer: "flex items-center gap-2 text-right",
+      "group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500",
+    brandPrefix: "text-fg/60",
+    brandSuffix: "text-fg",
+    controlsContainer:
+      "flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70",
+    switcherContainer: "flex items-center gap-3",
     button:
-      "group relative flex items-center gap-3 rounded-full border border-fg/15 bg-white/70 px-4 py-2 text-sm font-medium uppercase tracking-[0.32em] text-fg/80 shadow-[0_10px_30px_-18px_rgba(18,23,35,0.35)] backdrop-blur transition duration-300 ease-out hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
-    buttonIconWrapper:
-      "flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 transition duration-300 ease-out group-hover:bg-fg/20",
-    buttonIcon: "h-5 w-5 text-fg transition duration-300 ease-out",
+      "group inline-flex items-center gap-2 rounded-md px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg transition duration-300 ease-out hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500",
+    buttonIconWrapper: "inline-flex h-6 w-6 items-center justify-center text-current transition",
+    buttonIcon: "h-4 w-4",
   },
   overlay: {
-    container: "flex items-start justify-between gap-6",
+    container: "flex items-center justify-between gap-6",
     brandLink:
-      "pointer-events-auto inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-4 py-2 text-[0.65rem] uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur transition hover:border-fg/30 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
-    brandInner:
-      "inline-flex items-center rounded-full border border-fg/10 bg-white/70 px-3 py-2 shadow-soft backdrop-blur transition hover:border-fg/30 hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
+      "pointer-events-auto group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-200",
+    brandPrefix: "text-fg/60",
+    brandSuffix: "text-fg",
     controlsContainer:
-      "pointer-events-auto flex flex-col items-end gap-3 text-[0.65rem] uppercase tracking-[0.32em] text-fg/60",
-    switcherContainer: "flex items-center gap-2",
+      "pointer-events-auto flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70",
+    switcherContainer: "flex items-center gap-3",
     button:
-      "group flex items-center gap-3 rounded-full border border-fg/12 bg-white/70 px-6 py-2 text-[0.65rem] font-medium tracking-[0.28em] text-fg/80 shadow-soft backdrop-blur transition hover:-translate-y-0.5 hover:border-fg/40 hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg",
-    buttonIconWrapper:
-      "flex h-10 w-10 items-center justify-center rounded-full bg-fg/10 text-fg transition duration-300 ease-out group-hover:bg-fg group-hover:text-bg",
-    buttonIcon: "h-5 w-5",
+      "group inline-flex items-center gap-2 rounded-md px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg transition duration-300 ease-out hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-200",
+    buttonIconWrapper: "inline-flex h-6 w-6 items-center justify-center text-current transition",
+    buttonIcon: "h-4 w-4",
   },
 };


### PR DESCRIPTION
## Summary
- replace the nav brand monogram with the textual Duartois/Matheus Duarte pairing
- realign the header controls into a single horizontal row with updated spacing
- refresh default and overlay variants to share the new typography and focus styles

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc71d1ef4c832f86139114d0c00b00