### PR TITLE
Set language switcher to a static English pill

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,44 +1,17 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
-import clsx from "classnames";
 import "@/app/i18n/config";
 
-const LANGUAGES = [
-  { code: "pt", label: "PT" },
-  { code: "en", label: "EN" },
-] as const;
-
 export default function LanguageSwitcher() {
-  const { t, i18n } = useTranslation("common");
-  const currentLanguage = (i18n.resolvedLanguage || i18n.language || "pt").split("-")[0];
+  const { t } = useTranslation("common");
 
   return (
-    <div className="flex items-center gap-1.5 rounded-full border border-fg/12 bg-white/70 px-2 py-1 text-[0.6rem] font-medium uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur">
-      {LANGUAGES.map(({ code, label }) => {
-        const isActive = currentLanguage === code;
-        return (
-          <button
-            key={code}
-            type="button"
-            onClick={() => {
-              if (currentLanguage !== code) {
-                void i18n.changeLanguage(code);
-              }
-            }}
-            className={clsx(
-              "rounded-full px-2.5 py-1 transition duration-300 ease-out",
-              isActive
-                ? "bg-fg text-bg shadow-soft"
-                : "text-fg/60 hover:text-fg"
-            )}
-            aria-pressed={isActive}
-            aria-label={t("languageSwitcher.ariaLabel", { label })}
-          >
-            {label}
-          </button>
-        );
-      })}
-    </div>
+    <span
+      className="inline-flex items-center rounded-full border border-fg/12 bg-white/70 px-3 py-1 text-[0.6rem] font-medium uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur"
+      aria-label={t("languageSwitcher.ariaLabel")}
+    >
+      EN
+    </span>
   );
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "languageSwitcher": {
-    "ariaLabel": "Switch language to {{label}}"
+    "ariaLabel": "Language set to English"
   },
   "navbar": {
     "open": "Open navigation",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,6 @@
 {
   "languageSwitcher": {
-    "ariaLabel": "Alterar idioma para {{label}}"
+    "ariaLabel": "Idioma definido para inglês"
   },
   "navbar": {
     "open": "Abrir navegação",


### PR DESCRIPTION
## Summary
- replace the language toggle with a static English pill styled to match the reference layout
- update the aria-label copy in English and Portuguese locales to describe the static control

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc7261cbd0832f9cd9de2f9e41bcfb