### PR TITLE
feat: restyle theme toggle button

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -4,7 +4,7 @@ import clsx from "classnames";
 import { useTheme } from "@/app/theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
-import { MoonIcon, SunIcon } from "./icons/ThemeToggleIcons";
+import { MoonIcon } from "./icons/ThemeToggleIcons";
 
 export default function ThemeToggle() {
   const { theme, toggle } = useTheme();
@@ -24,27 +24,20 @@ export default function ThemeToggle() {
       type="button"
       onClick={toggle}
       className={clsx(
-        "group relative flex h-11 w-11 items-center justify-center rounded-full border border-fg/12 bg-white/70 text-fg/80 shadow-soft backdrop-blur transition-all duration-300 ease-pleasant",
-        "hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
-        theme === "dark"
-          ? "hover:border-accent3-400/70 hover:text-accent3-200"
-          : "hover:border-brand-400/70 hover:text-brand-600",
+        "group relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-accent3-400/50 bg-white/80 text-accent3-600 shadow-[0_14px_34px_-18px_rgba(31,176,186,0.85)] backdrop-blur transition-[transform,box-shadow,border-color,background-color,color] duration-300 ease-pleasant",
+        "hover:-translate-y-0.5 hover:border-accent3-300 hover:bg-accent3-400/10 hover:text-accent3-200 hover:shadow-[0_18px_40px_-18px_rgba(31,176,186,0.9)]",
+        "active:translate-y-0 active:scale-95 active:border-accent3-300/80 active:bg-accent3-400/15 active:text-accent3-100 active:shadow-[0_10px_26px_-18px_rgba(31,176,186,0.95)]",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent3-200",
+        "dark:border-accent3-300/60 dark:bg-accent3-500/10 dark:text-accent3-200",
       )}
       aria-label={t("themeToggle.ariaLabel", { theme: nextThemeLabel })}
       aria-pressed={theme === "dark"}
       title={t("themeToggle.title", { theme: titleThemeLabel })}
     >
-      {theme === "dark" ? (
-        <MoonIcon
-          aria-hidden
-          className="h-6 w-6 transform transition-transform duration-300 ease-pleasant group-active:scale-95"
-        />
-      ) : (
-        <SunIcon
-          aria-hidden
-          className="h-6 w-6 transform transition-transform duration-300 ease-pleasant group-active:scale-95"
-        />
-      )}
+      <MoonIcon
+        aria-hidden
+        className="h-6 w-6 transition-transform duration-300 ease-pleasant group-active:scale-95"
+      />
     </button>
   );
 }

--- a/components/icons/ThemeToggleIcons.tsx
+++ b/components/icons/ThemeToggleIcons.tsx
@@ -5,48 +5,6 @@ type IconProps = SVGProps<SVGSVGElement> & {
   className?: string;
 };
 
-export function SunIcon({ className, ...props }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      role="img"
-      aria-hidden
-      focusable="false"
-      className={clsx(
-        "h-6 w-6 text-brand-500 drop-shadow-sm transition-transform duration-300 ease-pleasant",
-        className,
-      )}
-      {...props}
-    >
-      <circle cx="12" cy="12" r="4.75" className="fill-current opacity-95" />
-      <circle
-        cx="12"
-        cy="12"
-        r="6.25"
-        className="stroke-current opacity-35"
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <g
-        className="stroke-current opacity-70"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <line x1="12" y1="2.5" x2="12" y2="5.2" />
-        <line x1="12" y1="18.8" x2="12" y2="21.5" />
-        <line x1="4.2" y1="12" x2="6.9" y2="12" />
-        <line x1="17.1" y1="12" x2="19.8" y2="12" />
-        <line x1="5.5" y1="5.5" x2="7.4" y2="7.4" />
-        <line x1="16.6" y1="16.6" x2="18.5" y2="18.5" />
-        <line x1="16.6" y1="7.4" x2="18.5" y2="5.5" />
-        <line x1="5.5" y1="18.5" x2="7.4" y2="16.6" />
-      </g>
-      <circle cx="12" cy="12" r="2.75" className="fill-brand-100 opacity-90" />
-    </svg>
-  );
-}
-
 export function MoonIcon({ className, ...props }: IconProps) {
   return (
     <svg
@@ -61,17 +19,27 @@ export function MoonIcon({ className, ...props }: IconProps) {
       {...props}
     >
       <path
-        className="fill-current"
-        d="M16.84 4.22a.75.75 0 0 1 .91-.91 9.75 9.75 0 1 1-12.62 12.62.75.75 0 0 1 .91-.91 7.5 7.5 0 0 0 10.8-10.8Z"
+        d="M20.3 14.35a8.25 8.25 0 1 1-10.65-10.6A6.75 6.75 0 0 0 20.3 14.35Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="opacity-90"
       />
       <path
-        className="fill-accent3-100/70"
-        d="M14.1 6.35a5.25 5.25 0 0 0-4.67 7.52 5.25 5.25 0 0 1 7.59-7.59 5.23 5.23 0 0 0-2.92-.93Z"
+        d="M13.8 4.85a6.05 6.05 0 0 0-.5 8.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.15"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="opacity-60"
       />
       <g className="fill-current opacity-80">
-        <circle cx="6.75" cy="6.75" r="1" className="opacity-70" />
-        <circle cx="18.25" cy="8.5" r="0.65" className="opacity-60" />
-        <circle cx="9.5" cy="18" r="0.85" className="opacity-50" />
+        <circle cx="7.1" cy="7.1" r="0.9" className="opacity-70" />
+        <circle cx="17.8" cy="8.85" r="0.6" className="opacity-60" />
+        <circle cx="10.2" cy="17.6" r="0.8" className="opacity-50" />
       </g>
     </svg>
   );


### PR DESCRIPTION
## Summary
- restyle the theme toggle button to match the reference surface and keep a moon glyph regardless of state
- refresh the moon icon stroke weights and remove unused sun icon code

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68dc76647700832fbec99a32a4438a73