### PR TITLE
Update menu toggle icon animation

### DIFF
--- a/components/MenuToggleIcon.tsx
+++ b/components/MenuToggleIcon.tsx
@@ -7,7 +7,6 @@ type MenuToggleIconProps = {
 } & Omit<SVGMotionProps<SVGSVGElement>, "animate" | "initial">;
 
 export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggleIconProps) {
-  const composedClassName = ["relative", className].filter(Boolean).join(" ");
   const state = isOpen ? "open" : "closed";
 
   return (
@@ -15,72 +14,48 @@ export default function MenuToggleIcon({ isOpen, className, ...rest }: MenuToggl
       viewBox="0 0 24 24"
       width={24}
       height={24}
-      className={composedClassName}
+      className={className}
       initial={false}
       animate={state}
       {...rest}
     >
-      <motion.circle
-        cx={12}
-        cy={12}
-        r={9.5}
-        fill="none"
+      <motion.line
+        x1={5}
+        x2={19}
         stroke="currentColor"
-        strokeWidth={0.5}
-        strokeOpacity={0.22}
-        variants={{
-          closed: { scale: 1, opacity: 0.55 },
-          open: { scale: 1.05, opacity: 0.35 },
-        }}
-        transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
-      />
-      <motion.path
-        variants={{
-          closed: {
-            d: "M5.5 8c1.9-.8 4.1-1.2 6.5-1.2s4.6.4 6.5 1.2",
-            rotate: 0,
-          },
-          open: {
-            d: "M6.2 6.2l11.6 11.6",
-            rotate: 2,
-          },
-        }}
-        transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
-        stroke="currentColor"
-        strokeWidth={1.6}
+        strokeWidth={1.4}
         strokeLinecap="round"
-      />
-      <motion.path
+        style={{ transformOrigin: "12px 12px" }}
         variants={{
-          closed: {
-            opacity: 1,
-            d: "M5 12h14",
-          },
-          open: {
-            opacity: 0,
-            d: "M12 12h0",
-          },
+          closed: { y1: 7, y2: 7, rotate: 0 },
+          open: { y1: 12, y2: 12, rotate: 45 },
         }}
-        transition={{ duration: 0.35, ease: [0.4, 0, 0.2, 1] }}
-        stroke="currentColor"
-        strokeWidth={1.5}
-        strokeLinecap="round"
+        transition={{ duration: 0.35, ease: [0.32, 0, 0.2, 1] }}
       />
-      <motion.path
-        variants={{
-          closed: {
-            d: "M18.5 16c-1.9.8-4.1 1.2-6.5 1.2s-4.6-.4-6.5-1.2",
-            rotate: 0,
-          },
-          open: {
-            d: "M17.8 6.2L6.2 17.8",
-            rotate: -2,
-          },
-        }}
-        transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
+      <motion.line
+        x1={5}
+        x2={19}
         stroke="currentColor"
-        strokeWidth={1.6}
+        strokeWidth={1.4}
         strokeLinecap="round"
+        variants={{
+          closed: { y1: 12, y2: 12, opacity: 1 },
+          open: { y1: 12, y2: 12, opacity: 0 },
+        }}
+        transition={{ duration: 0.25, ease: [0.32, 0, 0.2, 1] }}
+      />
+      <motion.line
+        x1={5}
+        x2={19}
+        stroke="currentColor"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        style={{ transformOrigin: "12px 12px" }}
+        variants={{
+          closed: { y1: 17, y2: 17, rotate: 0 },
+          open: { y1: 12, y2: 12, rotate: -45 },
+        }}
+        transition={{ duration: 0.35, ease: [0.32, 0, 0.2, 1] }}
       />
     </motion.svg>
   );


### PR DESCRIPTION
## Summary
- replace curved menu toggle paths with straight lines that morph into a geometric X
- tune framer-motion transitions for a thin, circle-free hamburger icon
- allow external classes to control the SVG size and color

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc772432e0832facbe60d1ca7e8b9b