### PR TITLE
Hide navbar header while overlay menu is open

### DIFF
--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -38,6 +38,7 @@ type NavOverlayProps = {
   navigationLinks: readonly NavigationLink[];
   socialLinks: readonly SocialLink[];
   overlayRef: RefObject<HTMLDivElement>;
+  triggerRef?: RefObject<HTMLButtonElement>;
 };
 
 export default function NavOverlay({
@@ -47,6 +48,7 @@ export default function NavOverlay({
   navigationLinks,
   socialLinks,
   overlayRef,
+  triggerRef,
 }: NavOverlayProps) {
   const { t } = useTranslation("common");
   const overlayPalette = useMemo<GradientPalette>(
@@ -218,6 +220,7 @@ export default function NavOverlay({
                   onToggle={onClose}
                   labels={{ open: t("navbar.open"), close: t("navbar.close") }}
                   onBrandClick={onClose}
+                  triggerRef={triggerRef}
                 />
               </motion.div>
             </motion.header>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -94,19 +94,21 @@ export default function Navbar() {
 
   return (
     <>
-      <div className="fixed inset-x-0 top-5 z-50 px-6 md:px-10">
-        <NavHeaderContent
-          isOpen={isOpen}
-          onToggle={() => setIsOpen((open) => !open)}
-          triggerRef={triggerRef}
-          labels={{ open: t("navbar.open"), close: t("navbar.close") }}
-          buttonProps={{
-            "aria-haspopup": "dialog",
-            "aria-expanded": isOpen,
-            "aria-controls": "main-navigation-overlay",
-          }}
-        />
-      </div>
+      {!isOpen && (
+        <div className="fixed inset-x-0 top-5 z-50 px-6 md:px-10">
+          <NavHeaderContent
+            isOpen={isOpen}
+            onToggle={() => setIsOpen((open) => !open)}
+            triggerRef={triggerRef}
+            labels={{ open: t("navbar.open"), close: t("navbar.close") }}
+            buttonProps={{
+              "aria-haspopup": "dialog",
+              "aria-expanded": isOpen,
+              "aria-controls": "main-navigation-overlay",
+            }}
+          />
+        </div>
+      )}
 
       <NavOverlay
         isOpen={isOpen}
@@ -115,6 +117,7 @@ export default function Navbar() {
         navigationLinks={navigationLinks}
         socialLinks={socialLinks}
         overlayRef={overlayRef}
+        triggerRef={triggerRef}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- stop rendering the fixed navbar header while the overlay menu is open to avoid duplicate controls
- pass the toggle button ref into the overlay header so focus management uses the same element when it is visible

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc7e1dca44832f97973e533f014028