### PR TITLE
Ensure preloader hides canvas until ready

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useCallback, useState } from "react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
 import CanvasRoot from "./three/CanvasRoot";
 
@@ -10,26 +10,46 @@ interface AppShellProps {
 
 export default function AppShell({ children }: AppShellProps) {
   const [isReady, setIsReady] = useState(false);
+  const [canRenderContent, setCanRenderContent] = useState(false);
+  const [isContentVisible, setIsContentVisible] = useState(false);
 
   const handleComplete = useCallback(() => {
     setIsReady(true);
   }, []);
 
+  useEffect(() => {
+    if (!isReady) {
+      setCanRenderContent(false);
+      setIsContentVisible(false);
+      return;
+    }
+
+    setCanRenderContent(true);
+
+    const id = requestAnimationFrame(() => {
+      setIsContentVisible(true);
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [isReady]);
+
   return (
     <>
       {!isReady && <Preloader onComplete={handleComplete} />}
-      <CanvasRoot isReady={isReady} />
-      <div
-        className={`transition-opacity duration-700 ${
-          isReady
-            ? "visible opacity-100"
-            : "pointer-events-none opacity-0 invisible"
-        }`}
-        aria-hidden={!isReady}
-        aria-busy={!isReady}
-      >
-        {children}
-      </div>
+      {isReady ? <CanvasRoot isReady={isReady} /> : null}
+      {canRenderContent ? (
+        <div
+          className={`transition-opacity duration-700 ${
+            isContentVisible
+              ? "visible opacity-100"
+              : "pointer-events-none opacity-0 invisible"
+          }`}
+          aria-hidden={!isContentVisible}
+          aria-busy={!isContentVisible}
+        >
+          {children}
+        </div>
+      ) : null}
     </>
   );
 }

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -10,21 +10,45 @@ interface CanvasRootProps {
 }
 
 export default function CanvasRoot({ isReady }: CanvasRootProps) {
-  const [mounted, setMounted] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    setMounted(true);
+    setHasMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (isReady) {
+      setShouldRender(true);
+    }
+  }, [isReady]);
+
+  useEffect(() => {
+    if (!shouldRender) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      setIsVisible(true);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [shouldRender]);
+
+  if (!hasMounted || !shouldRender) {
+    return null;
+  }
 
   return (
     <div
       className={classNames(
         "pointer-events-none fixed inset-0 -z-5 overflow-visible transition-opacity duration-700",
-        isReady ? "opacity-100" : "opacity-0",
+        isVisible ? "opacity-100" : "opacity-0",
       )}
-      aria-hidden={!isReady}
+      aria-hidden={!isVisible}
     >
-      {mounted ? <CoreCanvas /> : null}
+      <CoreCanvas />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render the Three.js canvas only after the preloader signals readiness
- delay mounting of page content until the preloader completes and fade it in smoothly

## Testing
- npm run verify:three

------
https://chatgpt.com/codex/tasks/task_e_68dc7fa276cc832f9e18aa8e92bd0cc7