### PR TITLE
Ensure Three.js canvas mounts before preloader completes

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -36,7 +36,7 @@ export default function AppShell({ children }: AppShellProps) {
   return (
     <>
       {!isReady && <Preloader onComplete={handleComplete} />}
-      {isReady ? <CanvasRoot isReady={isReady} /> : null}
+      <CanvasRoot isReady={isReady} />
       {canRenderContent ? (
         <div
           className={`transition-opacity duration-700 ${

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -13,32 +13,26 @@ interface CanvasRootProps {
 
 export default function CanvasRoot({ isReady }: CanvasRootProps) {
   const [hasMounted, setHasMounted] = useState(false);
-  const [shouldRender, setShouldRender] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
     setHasMounted(true);
+    setIsVisible(false);
   }, []);
 
   useEffect(() => {
-    if (isReady) {
-      setShouldRender(true);
-    }
-  }, [isReady]);
-
-  useEffect(() => {
-    if (!shouldRender) {
+    if (!hasMounted) {
       return;
     }
 
     const frame = requestAnimationFrame(() => {
-      setIsVisible(true);
+      setIsVisible(isReady);
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [shouldRender]);
+  }, [hasMounted, isReady]);
 
-  if (!hasMounted || !shouldRender) {
+  if (!hasMounted) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- render the Three.js canvas root regardless of preloader state so the global handle is ready
- update the canvas wrapper to mount after client hydration and fade based on readiness

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc85d1ce08832f8d495ddee3017c1c