### PR TITLE
Refine canvas layering and page wrappers

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -24,9 +24,8 @@ export default function AboutPage() {
   return (
     <>
       <Navbar />
-      <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-accent2-200/55 via-bg/75 to-bg dark:from-accent1-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
-        <div className="relative z-10 mx-auto flex min-h-screen max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-24">
+      <main className="relative z-10 flex min-h-screen w-full flex-col">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-24 bg-bg/70 backdrop-blur">
           <section className="flex-1 space-y-6">
             <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">
               {t("about.kicker")}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -30,9 +30,8 @@ export default function ContactPage() {
   return (
     <>
       <Navbar />
-      <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-bg/45 via-bg/85 to-bg" aria-hidden />
-        <div className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left">
+      <main className="relative z-10 flex min-h-screen w-full flex-col">
+        <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70 backdrop-blur">
           <div className="space-y-4">
             <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
               {t("contact.title")}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,11 +23,8 @@ export default function HomePage() {
   return (
     <>
       <Navbar />
-      <main className="relative min-h-screen overflow-hidden">
-        <div
-          className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.48),_transparent_55%),_linear-gradient(140deg,_rgba(218,184,255,0.55),_rgba(140,255,216,0.4))] dark:bg-[radial-gradient(circle_at_top,_rgba(46,20,64,0.65),_transparent_55%),_linear-gradient(140deg,_rgba(77,32,104,0.7),_rgba(23,94,87,0.55))]" aria-hidden
-        />
-        <section className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32">
+      <main className="relative z-10 flex min-h-screen w-full flex-col">
+        <section className="flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32 bg-bg/70 backdrop-blur">
           <div className="flex w-full max-w-3xl flex-col items-center gap-8 sm:gap-10">
             <span className="hero-animate text-sm font-light lowercase tracking-[0.28em] text-muted/80 sm:text-base" data-hero-index="0">
               {t("home.hero.kicker")}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -112,9 +112,8 @@ export default function WorkPage() {
   return (
     <>
       <Navbar />
-      <main className="relative min-h-screen overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 -z-20 bg-gradient-to-b from-accent3-200/55 via-bg/70 to-bg dark:from-accent2-800/35 dark:via-bg/85 dark:to-bg" aria-hidden />
-        <div className="relative z-10 mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20">
+      <main className="relative z-10 flex min-h-screen w-full flex-col">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20 bg-bg/70 backdrop-blur">
           <section className="lg:w-1/2">
             <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">
               {t("work.previewHint")}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -34,15 +34,15 @@ export default function AppShell({ children }: AppShellProps) {
   }, [isReady]);
 
   return (
-    <>
+    <div className="relative min-h-screen w-full overflow-hidden">
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
       {canRenderContent ? (
         <div
-          className={`transition-opacity duration-700 ${
+          className={`relative z-10 flex min-h-screen w-full flex-col transition-opacity duration-700 ${
             isContentVisible
               ? "visible opacity-100"
-              : "pointer-events-none opacity-0 invisible"
+              : "pointer-events-none invisible opacity-0"
           }`}
           aria-hidden={!isContentVisible}
           aria-busy={!isContentVisible}
@@ -50,6 +50,6 @@ export default function AppShell({ children }: AppShellProps) {
           {children}
         </div>
       ) : null}
-    </>
+    </div>
   );
 }

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -39,7 +39,7 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
   return (
     <div
       className={classNames(
-        "pointer-events-none fixed inset-0 -z-5 overflow-visible transition-opacity duration-700",
+        "pointer-events-none fixed inset-0 -z-50 overflow-visible transition-opacity duration-700",
         isVisible ? "opacity-100" : "opacity-0",
       )}
       aria-hidden={!isVisible}


### PR DESCRIPTION
## Summary
- update the app shell to wrap content above the fixed CanvasRoot while keeping the preloader
- simplify each page layout to rely on the shared shell and apply translucent backgrounds without extra gradient overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc938bb0bc832f8c09a7bccb4c671f