### PR TITLE
Refine navigation theming

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,14 @@
   --color-muted: 132 124 174;
   --glow-lilac: 218 184 255;
   --glow-mint: 158 255 210;
+  --nav-overlay-gradient:
+    radial-gradient(circle at 15% 10%, rgb(var(--glow-lilac) / 0.45), transparent 58%),
+    radial-gradient(circle at 80% 25%, rgb(var(--glow-mint) / 0.4), transparent 62%),
+    linear-gradient(135deg, rgb(var(--color-bg) / 0.96), rgb(var(--glow-lilac) / 0.42),
+        rgb(var(--glow-mint) / 0.38));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.85) 0%, rgb(var(--glow-lilac) / 0) 70%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.85) 0%, rgb(var(--glow-mint) / 0) 72%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.65) 0%, rgb(var(--glow-lilac) / 0) 74%);
 }
 
 /* Modo claro */
@@ -15,6 +23,14 @@
   --color-muted: 132 124 174;
   --glow-lilac: 218 184 255;
   --glow-mint: 158 255 210;
+  --nav-overlay-gradient:
+    radial-gradient(circle at 15% 10%, rgb(var(--glow-lilac) / 0.45), transparent 58%),
+    radial-gradient(circle at 80% 25%, rgb(var(--glow-mint) / 0.4), transparent 62%),
+    linear-gradient(135deg, rgb(var(--color-bg) / 0.96), rgb(var(--glow-lilac) / 0.42),
+        rgb(var(--glow-mint) / 0.38));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.85) 0%, rgb(var(--glow-lilac) / 0) 70%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.85) 0%, rgb(var(--glow-mint) / 0) 72%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.65) 0%, rgb(var(--glow-lilac) / 0) 74%);
 }
 
 /* Modo escuro */
@@ -24,6 +40,14 @@
   --color-muted: 164 158 210;
   --glow-lilac: 120 78 180;
   --glow-mint: 68 172 156;
+  --nav-overlay-gradient:
+    radial-gradient(circle at 18% 12%, rgb(var(--glow-lilac) / 0.42), transparent 60%),
+    radial-gradient(circle at 78% 28%, rgb(var(--glow-mint) / 0.38), transparent 65%),
+    linear-gradient(140deg, rgb(var(--color-bg) / 0.94), rgb(var(--glow-lilac) / 0.32),
+        rgb(var(--glow-mint) / 0.3));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.55) 0%, rgb(var(--glow-lilac) / 0) 72%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.6) 0%, rgb(var(--glow-mint) / 0) 74%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.5) 0%, rgb(var(--glow-lilac) / 0) 76%);
 }
 
 /* 2) Reset & base */
@@ -35,6 +59,22 @@ html, body {
   color: rgb(var(--color-fg));
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+.nav-overlay-surface {
+  background-image: var(--nav-overlay-gradient);
+}
+
+.nav-overlay-blob-a {
+  background-image: var(--nav-overlay-blob-a);
+}
+
+.nav-overlay-blob-b {
+  background-image: var(--nav-overlay-blob-b);
+}
+
+.nav-overlay-blob-c {
+  background-image: var(--nav-overlay-blob-c);
 }
 
 .btn {

--- a/app/theme/ThemeContext.tsx
+++ b/app/theme/ThemeContext.tsx
@@ -10,6 +10,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { getDefaultPalette } from "@/components/three/types";
+
 export type Theme = "light" | "dark";
 
 interface ThemeContextValue {
@@ -44,6 +46,22 @@ function resolveInitialTheme(): Theme {
   return getSystemTheme();
 }
 
+function syncThreeTheme(next: Theme) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const palette = getDefaultPalette(next);
+  window.__THREE_APP__?.setState({ theme: next, palette });
+}
+
+function persistTheme(next: Theme) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem("theme", next);
+  }
+  syncThreeTheme(next);
+}
+
 function applyTheme(theme: Theme) {
   const root = document.documentElement;
   root.setAttribute("data-theme", theme);
@@ -55,6 +73,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     applyTheme(theme);
+    syncThreeTheme(theme);
   }, [theme]);
 
   useEffect(() => {
@@ -72,9 +91,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = useCallback((next: Theme) => {
     setThemeState(() => {
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("theme", next);
-      }
+      persistTheme(next);
       return next;
     });
   }, []);
@@ -82,9 +99,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const toggle = useCallback(() => {
     setThemeState((current) => {
       const next = current === "dark" ? "light" : "dark";
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("theme", next);
-      }
+      persistTheme(next);
       return next;
     });
   }, []);

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -8,7 +8,7 @@ export default function LanguageSwitcher() {
 
   return (
     <span
-      className="inline-flex items-center rounded-full border border-fg/12 bg-white/70 px-3 py-1 text-[0.6rem] font-medium uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur"
+      className="inline-flex items-center rounded-full border border-fg/12 bg-bg/80 px-3 py-1 text-[0.6rem] font-medium uppercase tracking-[0.32em] text-fg/70 shadow-soft backdrop-blur transition-colors duration-300 ease-pleasant dark:border-fg/20 dark:bg-bg/40 dark:text-fg/75"
       aria-label={t("languageSwitcher.ariaLabel")}
     >
       EN

--- a/components/NavHeaderContent.tsx
+++ b/components/NavHeaderContent.tsx
@@ -93,28 +93,28 @@ const styles: Record<
   default: {
     container: "flex items-center justify-between gap-6",
     brandLink:
-      "group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500",
-    brandPrefix: "text-fg/60",
-    brandSuffix: "text-fg",
+      "group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-500 dark:hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
+    brandPrefix: "text-fg/60 dark:text-fg/70",
+    brandSuffix: "text-fg dark:text-fg",
     controlsContainer:
-      "flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70",
+      "flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70 dark:text-fg/75",
     switcherContainer: "flex items-center gap-3",
     button:
-      "group inline-flex items-center gap-2 rounded-md px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg transition duration-300 ease-out hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500",
+      "group inline-flex items-center gap-2 rounded-md border border-fg/15 bg-bg/80 px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg shadow-soft transition duration-300 ease-out hover:border-fg/25 hover:bg-bg hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70 dark:border-fg/20 dark:bg-bg/40 dark:hover:bg-bg/30",
     buttonIconWrapper: "inline-flex h-6 w-6 items-center justify-center text-current transition",
     buttonIcon: "h-4 w-4",
   },
   overlay: {
     container: "flex items-center justify-between gap-6",
     brandLink:
-      "pointer-events-auto group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-200",
-    brandPrefix: "text-fg/60",
-    brandSuffix: "text-fg",
+      "pointer-events-auto group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-400 dark:hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
+    brandPrefix: "text-fg/60 dark:text-fg/70",
+    brandSuffix: "text-fg dark:text-fg",
     controlsContainer:
-      "pointer-events-auto flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70",
+      "pointer-events-auto flex items-center justify-end gap-6 text-[0.75rem] font-medium uppercase tracking-[0.28em] text-fg/70 dark:text-fg/75",
     switcherContainer: "flex items-center gap-3",
     button:
-      "group inline-flex items-center gap-2 rounded-md px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg transition duration-300 ease-out hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-200",
+      "group inline-flex items-center gap-2 rounded-md border border-fg/20 bg-bg/70 px-4 py-2 text-[0.75rem] font-semibold uppercase tracking-[0.3em] text-fg transition duration-300 ease-out hover:border-fg/30 hover:bg-bg hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70 dark:border-fg/25 dark:bg-bg/40 dark:hover:bg-bg/35",
     buttonIconWrapper: "inline-flex h-6 w-6 items-center justify-center text-current transition",
     buttonIcon: "h-4 w-4",
   },

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -169,7 +169,7 @@ export default function NavOverlay({
           transition={{ duration: 0.25, ease: "easeInOut" }}
         >
           <motion.div
-            className="absolute inset-0 bg-gradient-to-br from-[#F3EBFF] via-[#FFE9F6] to-[#E6F7FF]"
+            className="absolute inset-0 nav-overlay-surface"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -179,9 +179,9 @@ export default function NavOverlay({
             className="pointer-events-none absolute inset-0"
             aria-hidden
           >
-            <div className="absolute -left-32 top-10 h-80 w-80 rounded-full bg-[radial-gradient(circle,#D3B8FF_0%,rgba(211,184,255,0)_70%)] blur-3xl" />
-            <div className="absolute bottom-[-6rem] left-1/3 h-[24rem] w-[24rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,#99F0E5_0%,rgba(153,240,229,0)_72%)] blur-3xl" />
-            <div className="absolute -right-20 top-[18%] h-[22rem] w-[22rem] rounded-full bg-[radial-gradient(circle,#FFB3DF_0%,rgba(255,179,223,0)_74%)] blur-3xl" />
+            <div className="nav-overlay-blob-a absolute -left-32 top-10 h-80 w-80 rounded-full blur-3xl" />
+            <div className="nav-overlay-blob-b absolute bottom-[-6rem] left-1/3 h-[24rem] w-[24rem] -translate-x-1/2 rounded-full blur-3xl" />
+            <div className="nav-overlay-blob-c absolute -right-20 top-[18%] h-[22rem] w-[22rem] rounded-full blur-3xl" />
           </div>
 
           <motion.div
@@ -204,7 +204,7 @@ export default function NavOverlay({
                 initial={{ y: -8, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: 0.1, duration: 0.3 }}
-                className="text-[0.7rem] font-medium uppercase tracking-[0.42em] text-fg/60"
+                className="text-[0.7rem] font-medium uppercase tracking-[0.42em] text-fg/60 dark:text-fg/70"
               >
                 {t("navbar.menu")}
               </motion.span>
@@ -227,20 +227,20 @@ export default function NavOverlay({
 
             <div className="relative flex flex-1 flex-col gap-12 px-6 pb-20 pt-10 md:flex-row md:px-12">
               <motion.div
-                className="pointer-events-none flex flex-col justify-between text-left text-sm uppercase tracking-[0.42em] text-fg/70 md:w-[45%]"
+                className="pointer-events-none flex flex-col justify-between text-left text-sm uppercase tracking-[0.42em] text-fg/70 dark:text-fg/75 md:w-[45%]"
                 initial={{ opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.25, duration: 0.4, ease: "easeOut" }}
               >
                 <div className="flex flex-col gap-8">
-                  <span className="text-[0.65rem] font-medium tracking-[0.48em] text-fg/60">
+                  <span className="text-[0.65rem] font-medium tracking-[0.48em] text-fg/60 dark:text-fg/70">
                     {t("navbar.menu")}
                   </span>
-                  <p className="max-w-xs text-pretty text-[0.72rem] font-light leading-relaxed tracking-[0.28em] text-fg/70">
+                  <p className="max-w-xs text-pretty text-[0.72rem] font-light leading-relaxed tracking-[0.28em] text-fg/70 dark:text-fg/75">
                     immersions in light, sound, and code — follow the path or jump to a collaboration.
                   </p>
                 </div>
-                <div className="hidden h-px w-24 bg-fg/15 md:block" />
+                <div className="hidden h-px w-24 bg-fg/15 dark:bg-fg/25 md:block" />
               </motion.div>
 
               <div className="flex w-full flex-1 flex-col items-end justify-center md:w-[55%]">
@@ -273,16 +273,16 @@ export default function NavOverlay({
                           onMouseEnter={handleLinkFocus(name as VariantName)}
                           onFocus={handleLinkFocus(name as VariantName)}
                           onBlur={handleLinkBlur}
-                          className="group relative inline-flex w-full items-baseline justify-end gap-6 px-2 py-1 text-right font-light text-fg/90 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg"
+                          className="group relative inline-flex w-full items-baseline justify-end gap-6 px-2 py-1 text-right font-light text-fg/90 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-fg dark:text-fg hover:text-fg dark:hover:text-fg"
                         >
-                          <span className="text-[clamp(0.75rem,1.4vw,0.95rem)] font-normal tracking-[0.32em] text-fg/45">
+                          <span className="text-[clamp(0.75rem,1.4vw,0.95rem)] font-normal tracking-[0.32em] text-fg/45 dark:text-fg/50">
                             {String(index + 1).padStart(2, "0")}
                           </span>
-                          <span className="relative inline-block overflow-hidden text-[clamp(2.5rem,4.8vw,3.9rem)] uppercase tracking-[0.2em] text-fg/90">
+                          <span className="relative inline-block overflow-hidden text-[clamp(2.5rem,4.8vw,3.9rem)] uppercase tracking-[0.2em] text-fg/90 dark:text-fg">
                             <span className="block translate-y-0 transition-transform duration-300 ease-out group-hover:-translate-y-1">
                               {name}
                             </span>
-                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/70 transition-transform duration-300 ease-out group-hover:scale-x-100" />
+                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/70 transition-transform duration-300 ease-out group-hover:scale-x-100 dark:bg-fg/60" />
                           </span>
                         </Link>
                       </motion.li>
@@ -296,11 +296,11 @@ export default function NavOverlay({
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.45, duration: 0.35 }}
                 >
-                  <span className="flex items-center gap-3 text-[0.58rem] uppercase tracking-[0.38em] text-fg/60">
-                    <span className="hidden h-px w-10 bg-fg/20 md:block" />
+                  <span className="flex items-center gap-3 text-[0.58rem] uppercase tracking-[0.38em] text-fg/60 dark:text-fg/70">
+                    <span className="hidden h-px w-10 bg-fg/20 dark:bg-fg/30 md:block" />
                     {t("navOverlay.socialHeading")}
                   </span>
-                  <ul className="flex flex-col items-end gap-3 text-[0.84rem] font-light uppercase tracking-[0.32em] text-fg/75">
+                  <ul className="flex flex-col items-end gap-3 text-[0.84rem] font-light uppercase tracking-[0.32em] text-fg/75 dark:text-fg/80">
                     {socialLinks.map(({ label, href }) => (
                       <li key={label}>
                         <Link
@@ -308,16 +308,16 @@ export default function NavOverlay({
                           target="_blank"
                           rel="noreferrer noopener"
                           prefetch={false}
-                          className="group relative inline-flex items-center gap-3 text-fg/70 transition-colors duration-200 ease-out hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                          className="group relative inline-flex items-center gap-3 text-fg/70 transition-colors duration-200 ease-out hover:text-fg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg dark:text-fg/75 dark:hover:text-fg"
                         >
-                          <span aria-hidden className="text-fg/45 transition-colors duration-200 ease-out group-hover:text-fg">
+                          <span aria-hidden className="text-fg/45 transition-colors duration-200 ease-out group-hover:text-fg dark:text-fg/55">
                             &gt;
                           </span>
                           <span className="relative block overflow-hidden">
                             <span className="block translate-y-0 transition-transform duration-200 ease-out group-hover:-translate-y-[2px]">
                               {label}
                             </span>
-                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/60 transition-transform duration-200 ease-out group-hover:scale-x-100" />
+                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/60 transition-transform duration-200 ease-out group-hover:scale-x-100 dark:bg-fg/50" />
                           </span>
                         </Link>
                       </li>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -24,11 +24,11 @@ export default function ThemeToggle() {
       type="button"
       onClick={toggle}
       className={clsx(
-        "group relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-accent3-400/50 bg-white/80 text-accent3-600 shadow-[0_14px_34px_-18px_rgba(31,176,186,0.85)] backdrop-blur transition-[transform,box-shadow,border-color,background-color,color] duration-300 ease-pleasant",
-        "hover:-translate-y-0.5 hover:border-accent3-300 hover:bg-accent3-400/10 hover:text-accent3-200 hover:shadow-[0_18px_40px_-18px_rgba(31,176,186,0.9)]",
-        "active:translate-y-0 active:scale-95 active:border-accent3-300/80 active:bg-accent3-400/15 active:text-accent3-100 active:shadow-[0_10px_26px_-18px_rgba(31,176,186,0.95)]",
-        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent3-200",
-        "dark:border-accent3-300/60 dark:bg-accent3-500/10 dark:text-accent3-200",
+        "group relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-fg/15 bg-bg/85 text-fg shadow-[0_14px_34px_-18px_rgb(var(--color-fg)_/_0.18)] backdrop-blur transition-[transform,box-shadow,border-color,background-color,color] duration-300 ease-pleasant",
+        "hover:-translate-y-0.5 hover:border-fg/25 hover:bg-bg hover:text-fg hover:shadow-[0_18px_40px_-18px_rgb(var(--color-fg)_/_0.22)]",
+        "active:translate-y-0 active:scale-95 active:border-fg/30 active:bg-bg/80 active:shadow-[0_10px_26px_-18px_rgb(var(--color-fg)_/_0.26)]",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
+        "dark:border-fg/25 dark:bg-bg/40 dark:text-fg dark:hover:bg-bg/35 dark:active:bg-bg/30",
       )}
       aria-label={t("themeToggle.ariaLabel", { theme: nextThemeLabel })}
       aria-pressed={theme === "dark"}


### PR DESCRIPTION
## Summary
- replace fixed colors in navigation components with theme tokens and dark-mode variants for consistent contrast
- introduce theme-aware overlay gradients using shared CSS variables
- synchronize the three.js palette when toggling themes to keep scenes aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc9647ccb4832f9e8f5d0f5af7c1fa