### PR TITLE
feat: extract animated text component

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import Navbar from "../../components/Navbar";
+import AnimatedText from "../../components/AnimatedText";
 import Link from "next/link";
 import { Trans, useTranslation } from "react-i18next";
 import Image from "next/image";
@@ -27,17 +28,55 @@ export default function AboutPage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-24 bg-bg/70 backdrop-blur">
           <section className="flex-1 space-y-6">
-            <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">
+            <AnimatedText
+              as="p"
+              underline={false}
+              trigger="none"
+              className="block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+            >
               {t("about.kicker")}
-            </p>
+            </AnimatedText>
             <div className="space-y-4">
-              <h1 className="text-5xl font-semibold text-fg sm:text-6xl">{t("about.title")}</h1>
-              <p className="text-lg text-fg/70 sm:text-xl">{t("about.subtitle")}</p>
+              <AnimatedText
+                as="h1"
+                underline={false}
+                trigger="none"
+                className="block text-5xl font-semibold text-fg sm:text-6xl"
+              >
+                {t("about.title")}
+              </AnimatedText>
+              <AnimatedText
+                as="p"
+                underline={false}
+                trigger="none"
+                className="block text-lg text-fg/70 sm:text-xl"
+              >
+                {t("about.subtitle")}
+              </AnimatedText>
             </div>
             <div className="space-y-4 text-base leading-relaxed text-fg/80 sm:text-lg">
-              <p className="lowercase">{t("about.paragraphs.first")}</p>
-              <p className="lowercase">{t("about.paragraphs.second")}</p>
-              <p className="lowercase">
+              <AnimatedText
+                as="p"
+                underline={false}
+                trigger="none"
+                className="block lowercase"
+              >
+                {t("about.paragraphs.first")}
+              </AnimatedText>
+              <AnimatedText
+                as="p"
+                underline={false}
+                trigger="none"
+                className="block lowercase"
+              >
+                {t("about.paragraphs.second")}
+              </AnimatedText>
+              <AnimatedText
+                as="p"
+                underline={false}
+                trigger="none"
+                className="block lowercase"
+              >
                 <Trans
                   i18nKey="about.paragraphs.third"
                   ns="common"
@@ -52,7 +91,7 @@ export default function AboutPage() {
                     ),
                   }}
                 />
-              </p>
+              </AnimatedText>
             </div>
             <div className="flex flex-wrap gap-3 pt-6">
               <Link

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from "react";
 import Navbar from "../../components/Navbar";
+import AnimatedText from "../../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -33,12 +34,22 @@ export default function ContactPage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70 backdrop-blur">
           <div className="space-y-4">
-            <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+            <AnimatedText
+              as="h1"
+              underline={false}
+              trigger="none"
+              className="block text-4xl font-semibold text-fg sm:text-5xl"
+            >
               {t("contact.title")}
-            </h1>
-            <p className="text-base text-fg/80 sm:text-lg">
+            </AnimatedText>
+            <AnimatedText
+              as="p"
+              underline={false}
+              trigger="none"
+              className="block text-base text-fg/80 sm:text-lg"
+            >
               {t("contact.subtitle")}
-            </p>
+            </AnimatedText>
           </div>
           <form
             onSubmit={handleSubmit}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import Navbar from "../components/Navbar";
+import AnimatedText from "../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
@@ -26,15 +27,33 @@ export default function HomePage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <section className="flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32 bg-bg/70 backdrop-blur">
           <div className="flex w-full max-w-3xl flex-col items-center gap-8 sm:gap-10">
-            <span className="hero-animate text-sm font-light lowercase tracking-[0.28em] text-muted/80 sm:text-base" data-hero-index="0">
+            <AnimatedText
+              as="span"
+              underline={false}
+              trigger="none"
+              className="hero-animate text-sm font-light lowercase tracking-[0.28em] text-muted/80 sm:text-base"
+              data-hero-index="0"
+            >
               {t("home.hero.kicker")}
-            </span>
-            <h1 className="hero-animate text-balance text-4xl font-light lowercase leading-tight text-fg sm:text-5xl md:text-6xl" data-hero-index="1">
+            </AnimatedText>
+            <AnimatedText
+              as="h1"
+              underline={false}
+              trigger="none"
+              className="hero-animate block text-balance text-4xl font-light lowercase leading-tight text-fg sm:text-5xl md:text-6xl"
+              data-hero-index="1"
+            >
               {t("home.hero.title")}
-            </h1>
-            <p className="hero-animate max-w-2xl text-pretty text-base font-light lowercase text-muted sm:text-lg" data-hero-index="2">
+            </AnimatedText>
+            <AnimatedText
+              as="p"
+              underline={false}
+              trigger="none"
+              className="hero-animate block max-w-2xl text-pretty text-base font-light lowercase text-muted sm:text-lg"
+              data-hero-index="2"
+            >
               {t("home.hero.subtitle")}
-            </p>
+            </AnimatedText>
             <div className="hero-animate flex flex-col items-center gap-3 sm:flex-row" data-hero-index="3">
               <Link
                 href="/work"

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import Navbar from "../../components/Navbar";
+import AnimatedText from "../../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -115,15 +116,30 @@ export default function WorkPage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20 bg-bg/70 backdrop-blur">
           <section className="lg:w-1/2">
-            <p className="text-xs font-medium uppercase tracking-[0.42em] text-fg/65">
+            <AnimatedText
+              as="p"
+              underline={false}
+              trigger="none"
+              className="block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+            >
               {t("work.previewHint")}
-            </p>
-            <h1 className="mt-4 text-4xl font-medium text-fg sm:text-5xl">
+            </AnimatedText>
+            <AnimatedText
+              as="h1"
+              underline={false}
+              trigger="none"
+              className="mt-4 block text-4xl font-medium text-fg sm:text-5xl"
+            >
               {t("work.title")}
-            </h1>
-            <p className="mt-6 max-w-xl text-base leading-relaxed text-fg/80 sm:text-lg">
+            </AnimatedText>
+            <AnimatedText
+              as="p"
+              underline={false}
+              trigger="none"
+              className="mt-6 block max-w-xl text-base leading-relaxed text-fg/80 sm:text-lg"
+            >
               {t("work.subtitle")}
-            </p>
+            </AnimatedText>
             <ul className="mt-10 flex flex-col gap-3">
               {projectOrder.map((projectKey) => (
                 <li key={projectKey}>
@@ -137,9 +153,14 @@ export default function WorkPage() {
                         : "border-fg/20 bg-bg/60 hover:border-fg/40 hover:bg-fg/5"
                     }`}
                   >
-                    <span className="text-lg font-medium uppercase tracking-[0.28em] text-fg">
+                    <AnimatedText
+                      as="span"
+                      underline={false}
+                      trigger="self"
+                      className="block text-lg font-medium uppercase tracking-[0.28em] text-fg"
+                    >
                       {t(`work.projects.${projectKey}.title`)}
-                    </span>
+                    </AnimatedText>
                     <span className="text-sm font-medium text-fg/55">
                       {t(`work.projects.${projectKey}.year`)}
                     </span>

--- a/components/AnimatedText.tsx
+++ b/components/AnimatedText.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import clsx from "classnames";
+import { type ComponentPropsWithoutRef, type ElementType, type ReactNode } from "react";
+
+const defaultElement = "span" satisfies ElementType;
+
+const hoverClassByTrigger = {
+  group: {
+    translate: "group-hover:-translate-y-1 group-focus-visible:-translate-y-1",
+    scale: "group-hover:scale-x-100 group-focus-visible:scale-x-100",
+  },
+  self: {
+    translate: "hover:-translate-y-1 focus-visible:-translate-y-1",
+    scale: "hover:scale-x-100 focus-visible:scale-x-100",
+  },
+  none: {
+    translate: "",
+    scale: "",
+  },
+} as const;
+
+export type AnimatedTextProps<T extends ElementType = typeof defaultElement> = {
+  as?: T;
+  children: ReactNode;
+  /**
+   * Controls whether the underline indicator is rendered.
+   * Defaults to `true` to match the navigation treatment.
+   */
+  underline?: boolean;
+  /**
+   * Determines which element controls the hover/focus animation.
+   * Use `group` (default) when the component lives inside a parent with the
+   * `group` class, or `self` when the component itself handles interactions.
+   */
+  trigger?: "group" | "self" | "none";
+  innerClassName?: string;
+  underlineClassName?: string;
+  textClassName?: string;
+};
+
+type PolymorphicProps<T extends ElementType> = AnimatedTextProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof AnimatedTextProps<T>>;
+
+type AnimatedTextComponent = <T extends ElementType = typeof defaultElement>(
+  props: PolymorphicProps<T>,
+) => JSX.Element;
+
+const AnimatedText: AnimatedTextComponent = ({
+  as,
+  children,
+  className,
+  underline = true,
+  trigger = "group",
+  innerClassName,
+  underlineClassName,
+  textClassName,
+  ...rest
+}) => {
+  const Component = (as ?? defaultElement) as ElementType;
+  const hoverClasses = hoverClassByTrigger[trigger];
+
+  return (
+    <Component
+      {...rest}
+      className={clsx(
+        "relative inline-block overflow-hidden align-baseline",
+        className,
+      )}
+    >
+      <span
+        className={clsx(
+          "relative block",
+          "motion-reduce:transition-none motion-reduce:[transform:translateY(0)!important]",
+          innerClassName,
+        )}
+      >
+        <span
+          className={clsx(
+            "block translate-y-0 transition-transform duration-300 ease-out",
+            hoverClasses.translate,
+            "motion-reduce:transition-none motion-reduce:[transform:translateY(0)!important]",
+            textClassName,
+          )}
+        >
+          {children}
+        </span>
+        {underline && (
+          <span
+            aria-hidden
+            className={clsx(
+              "pointer-events-none absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-current",
+              "transition-transform duration-300 ease-out",
+              hoverClasses.scale,
+              "motion-reduce:scale-x-100 motion-reduce:transition-none",
+              underlineClassName,
+            )}
+          />
+        )}
+      </span>
+    </Component>
+  );
+};
+
+export default AnimatedText;

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import "@/app/i18n/config";
 
 import NavHeaderContent from "./NavHeaderContent";
+import AnimatedText from "./AnimatedText";
 import {
   getDefaultPalette,
   type GradientPalette,
@@ -278,12 +279,13 @@ export default function NavOverlay({
                           <span className="text-[clamp(0.75rem,1.4vw,0.95rem)] font-normal tracking-[0.32em] text-fg/45 dark:text-fg/50">
                             {String(index + 1).padStart(2, "0")}
                           </span>
-                          <span className="relative inline-block overflow-hidden text-[clamp(2.5rem,4.8vw,3.9rem)] uppercase tracking-[0.2em] text-fg/90 dark:text-fg">
-                            <span className="block translate-y-0 transition-transform duration-300 ease-out group-hover:-translate-y-1">
-                              {name}
-                            </span>
-                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/70 transition-transform duration-300 ease-out group-hover:scale-x-100 dark:bg-fg/60" />
-                          </span>
+                          <AnimatedText
+                            className="text-[clamp(2.5rem,4.8vw,3.9rem)] uppercase tracking-[0.2em] text-fg/90 dark:text-fg"
+                            underlineClassName="bg-fg/70 dark:bg-fg/60"
+                            textClassName="font-light"
+                          >
+                            {name}
+                          </AnimatedText>
                         </Link>
                       </motion.li>
                     ))}
@@ -313,12 +315,13 @@ export default function NavOverlay({
                           <span aria-hidden className="text-fg/45 transition-colors duration-200 ease-out group-hover:text-fg dark:text-fg/55">
                             &gt;
                           </span>
-                          <span className="relative block overflow-hidden">
-                            <span className="block translate-y-0 transition-transform duration-200 ease-out group-hover:-translate-y-[2px]">
-                              {label}
-                            </span>
-                            <span className="absolute inset-x-0 bottom-0 h-px origin-left scale-x-0 bg-fg/60 transition-transform duration-200 ease-out group-hover:scale-x-100 dark:bg-fg/50" />
-                          </span>
+                          <AnimatedText
+                            className="text-fg/70 transition-colors duration-200 ease-out group-hover:text-fg dark:text-fg/75 dark:group-hover:text-fg"
+                            underlineClassName="bg-fg/60 dark:bg-fg/50"
+                            textClassName="text-[0.84rem] font-light uppercase tracking-[0.32em]"
+                          >
+                            {label}
+                          </AnimatedText>
                         </Link>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary
- add an AnimatedText component to encapsulate the menu text animation with reduced motion safeguards
- replace hero and section text across the home, work, about, and contact pages to render through the new component
- update the navigation overlay to use the shared animation utility for primary and social links while keeping contrast controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc981f3f44832f8daf5b3be0321c14