### PR TITLE
Align background three.js forms with Sharlee reference

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,61 +1,59 @@
 @import "tailwindcss";
 
 :root {
-  --color-bg: 246 243 255;
-  --color-fg: 27 22 46;
-  --color-muted: 132 124 174;
-  --glow-lilac: 218 184 255;
-  --glow-mint: 158 255 210;
+  --color-bg: 237 237 246;
+  --color-fg: 38 35 56;
+  --color-muted: 128 124 156;
+  --glow-lilac: 249 215 251;
+  --glow-mint: 162 230 255;
   --nav-overlay-gradient:
-    radial-gradient(circle at 15% 10%, rgb(var(--glow-lilac) / 0.45), transparent 58%),
-    radial-gradient(circle at 80% 25%, rgb(var(--glow-mint) / 0.4), transparent 62%),
-    linear-gradient(135deg, rgb(var(--color-bg) / 0.96), rgb(var(--glow-lilac) / 0.42),
-        rgb(var(--glow-mint) / 0.38));
-  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.85) 0%, rgb(var(--glow-lilac) / 0) 70%);
-  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.85) 0%, rgb(var(--glow-mint) / 0) 72%);
-  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.65) 0%, rgb(var(--glow-lilac) / 0) 74%);
+    radial-gradient(circle at 14% 8%, rgb(var(--glow-lilac) / 0.52), transparent 60%),
+    radial-gradient(circle at 78% 22%, rgb(var(--glow-mint) / 0.46), transparent 64%),
+    linear-gradient(135deg, rgb(255 255 255 / 0.72), rgb(var(--color-bg)));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.75) 0%, rgb(var(--glow-lilac) / 0) 70%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.78) 0%, rgb(var(--glow-mint) / 0) 72%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.58) 0%, rgb(var(--glow-lilac) / 0) 74%);
 }
 
 /* Modo claro */
 :root[data-theme="light"], :root.light {
-  --color-bg: 246 243 255;
-  --color-fg: 27 22 46;
-  --color-muted: 132 124 174;
-  --glow-lilac: 218 184 255;
-  --glow-mint: 158 255 210;
+  --color-bg: 237 237 246;
+  --color-fg: 38 35 56;
+  --color-muted: 128 124 156;
+  --glow-lilac: 249 215 251;
+  --glow-mint: 162 230 255;
   --nav-overlay-gradient:
-    radial-gradient(circle at 15% 10%, rgb(var(--glow-lilac) / 0.45), transparent 58%),
-    radial-gradient(circle at 80% 25%, rgb(var(--glow-mint) / 0.4), transparent 62%),
-    linear-gradient(135deg, rgb(var(--color-bg) / 0.96), rgb(var(--glow-lilac) / 0.42),
-        rgb(var(--glow-mint) / 0.38));
-  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.85) 0%, rgb(var(--glow-lilac) / 0) 70%);
-  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.85) 0%, rgb(var(--glow-mint) / 0) 72%);
-  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.65) 0%, rgb(var(--glow-lilac) / 0) 74%);
+    radial-gradient(circle at 14% 8%, rgb(var(--glow-lilac) / 0.52), transparent 60%),
+    radial-gradient(circle at 78% 22%, rgb(var(--glow-mint) / 0.46), transparent 64%),
+    linear-gradient(135deg, rgb(255 255 255 / 0.72), rgb(var(--color-bg)));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.75) 0%, rgb(var(--glow-lilac) / 0) 70%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.78) 0%, rgb(var(--glow-mint) / 0) 72%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.58) 0%, rgb(var(--glow-lilac) / 0) 74%);
 }
 
 /* Modo escuro */
 :root[data-theme="dark"], :root.dark {
-  --color-bg: 15 12 26;
-  --color-fg: 236 233 255;
-  --color-muted: 164 158 210;
-  --glow-lilac: 120 78 180;
-  --glow-mint: 68 172 156;
+  --color-bg: 46 47 57;
+  --color-fg: 245 245 252;
+  --color-muted: 185 187 204;
+  --glow-lilac: 92 94 109;
+  --glow-mint: 106 109 122;
   --nav-overlay-gradient:
-    radial-gradient(circle at 18% 12%, rgb(var(--glow-lilac) / 0.42), transparent 60%),
-    radial-gradient(circle at 78% 28%, rgb(var(--glow-mint) / 0.38), transparent 65%),
-    linear-gradient(140deg, rgb(var(--color-bg) / 0.94), rgb(var(--glow-lilac) / 0.32),
-        rgb(var(--glow-mint) / 0.3));
-  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.55) 0%, rgb(var(--glow-lilac) / 0) 72%);
-  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.6) 0%, rgb(var(--glow-mint) / 0) 74%);
-  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.5) 0%, rgb(var(--glow-lilac) / 0) 76%);
+    radial-gradient(circle at 20% 10%, rgb(var(--glow-lilac) / 0.5), transparent 62%),
+    radial-gradient(circle at 76% 26%, rgb(var(--glow-mint) / 0.45), transparent 66%),
+    linear-gradient(140deg, rgb(var(--color-bg) / 1), rgb(var(--color-bg) / 0.92));
+  --nav-overlay-blob-a: radial-gradient(circle, rgb(var(--glow-lilac) / 0.65) 0%, rgb(var(--glow-lilac) / 0) 72%);
+  --nav-overlay-blob-b: radial-gradient(circle, rgb(var(--glow-mint) / 0.68) 0%, rgb(var(--glow-mint) / 0) 74%);
+  --nav-overlay-blob-c: radial-gradient(circle, rgb(var(--glow-lilac) / 0.55) 0%, rgb(var(--glow-lilac) / 0) 76%);
 }
 
 /* 2) Reset & base */
 html, body, #__next { height: 100% }
 html, body {
-  background: radial-gradient(circle at 20% 0%, rgb(var(--glow-lilac) / 0.6), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgb(var(--glow-mint) / 0.45), transparent 60%),
-    linear-gradient(140deg, rgb(var(--glow-lilac) / 0.35), rgb(var(--glow-mint) / 0.3));
+  background:
+    radial-gradient(circle at 18% 8%, rgb(var(--glow-lilac) / 0.55), transparent 58%),
+    radial-gradient(circle at 82% 22%, rgb(var(--glow-mint) / 0.45), transparent 62%),
+    linear-gradient(140deg, rgb(var(--color-bg) / 1), rgb(var(--color-bg) / 0.92));
   color: rgb(var(--color-fg));
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -28,27 +28,27 @@ export type VariantState = Record<ShapeId, ShapeTransform>;
 
 const createFramedVariant = (): VariantState => ({
   torus270A: {
-    position: [-1.68, 1.58, 0.16],
-    rotation: [0.08, -0.1, 0.04],
+    position: [-0.48, 0.88, 0.18],
+    rotation: [0.16, 0.18, 0.42],
   },
   torus270B: {
-    position: [-1.86, -1.24, -0.36],
-    rotation: [-0.12, 0.18, 0.28],
+    position: [-0.52, -0.96, -0.2],
+    rotation: [-0.12, 0.22, -0.36],
   },
   semi180A: {
-    position: [1.74, 1.36, 0.18],
-    rotation: [-0.05, 0.06, -0.08],
+    position: [0.78, 0.36, 0.16],
+    rotation: [-0.08, 0.26, -0.22],
   },
   semi180B: {
-    position: [2.04, -0.92, -0.28],
-    rotation: [0.07, -0.05, -0.22],
+    position: [0.92, -1.42, 0.1],
+    rotation: [0.14, -0.14, -0.28],
   },
   wave: {
-    position: [0.08, 0.18, 0.42],
-    rotation: [0, 0, 0.08],
+    position: [-0.24, 1.98, 0.3],
+    rotation: [0.38, -0.22, 0.56],
   },
   sphere: {
-    position: [0.96, -1.4, 0.54],
+    position: [1.24, 1.64, 0.44],
     rotation: [0, 0, 0],
   },
 });
@@ -62,21 +62,21 @@ export const variantMapping: Record<VariantName, VariantState> = {
 };
 
 export const LIGHT_THEME_PALETTE: GradientPalette = [
-  ["#f9e9ff", "#e6c7ff", "#d0a4ff", "#b67cff"],
-  ["#ffe9fb", "#ffc4ef", "#ffa1e3", "#ff77d2"],
-  ["#e8fff6", "#c2ffe6", "#99f7d6", "#64e8c2"],
-  ["#f3ffe6", "#d8ffb8", "#baff85", "#8af55d"],
-  ["#fff4e5", "#ffd5b5", "#ffb886", "#ff9362"],
-  ["#e9f6ff", "#c3e4ff", "#9accff", "#6faeff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
+  ["#f9d7fb", "#f4f6c6", "#a8f0d6", "#a0c8ff"],
 ];
 
 export const DARK_THEME_PALETTE: GradientPalette = [
-  ["#2b1a44", "#3c2b63", "#5b3f96", "#8e63e6"],
-  ["#3b1031", "#5a1f50", "#872c77", "#ff63c5"],
-  ["#0a2c25", "#11433a", "#146259", "#21d7a8"],
-  ["#12240f", "#1d3a18", "#2a5927", "#6dff63"],
-  ["#331d0f", "#4d2a16", "#72401f", "#ffa564"],
-  ["#12203c", "#1c3056", "#2f4f8b", "#6aa7ff"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
+  ["#2f3039", "#3a3b45", "#454651", "#52535f"],
 ];
 
 export type ThemeName = "light" | "dark";


### PR DESCRIPTION
## Summary
- remodel the hero three.js geometries, gradients, and layout so the background forms match the Sharlee reference in both themes
- refresh theme palettes and global background variables to deliver the requested pastel light mode and charcoal dark mode styling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc9d6b42b0832f9a9566892531c225