### PR TITLE
Add opacity control to three materials and pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -19,6 +19,7 @@ export default function AboutPage() {
       palette: getDefaultPalette(previous.theme),
       parallax: true,
       hovered: false,
+      opacity: 0.3,
     }));
   }, []);
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -18,6 +18,7 @@ export default function ContactPage() {
       palette: getDefaultPalette(previous.theme),
       parallax: true,
       hovered: false,
+      opacity: 0.3,
     }));
   }, []);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ export default function HomePage() {
       palette: getDefaultPalette(previous.theme),
       parallax: true,
       hovered: false,
+      opacity: 1,
     }));
   }, []);
 

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -44,6 +44,7 @@ export default function WorkPage() {
       palette: getDefaultPalette(previous.theme),
       parallax: true,
       hovered: false,
+      opacity: 0.3,
     }));
   }, []);
 
@@ -53,6 +54,7 @@ export default function WorkPage() {
       variantName: preview.variantName,
       parallax: false,
       hovered: true,
+      opacity: 0.3,
     });
   }, [activePreview]);
 
@@ -63,6 +65,7 @@ export default function WorkPage() {
         palette: getDefaultPalette(previous.theme),
         parallax: true,
         hovered: false,
+        opacity: 0.3,
       }));
     };
   }, []);

--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -107,6 +107,7 @@ export default function NavOverlay({
         cursorBoost: 0.08,
         pointerDriver: "manual",
         manualPointer: pointerTarget,
+        opacity: 1,
       });
     } else if (!isOpen && wasOpenRef.current) {
       const snapshot = initialSceneStateRef.current;
@@ -119,6 +120,7 @@ export default function NavOverlay({
           cursorBoost: snapshot.cursorBoost,
           pointerDriver: snapshot.pointerDriver,
           manualPointer: snapshot.manualPointer,
+          opacity: snapshot.opacity,
         }));
       } else {
         const current = app.bundle.getState();
@@ -129,6 +131,7 @@ export default function NavOverlay({
           cursorBoost: 0,
           pointerDriver: "device",
           manualPointer: { x: 0, y: 0 },
+          opacity: 1,
         });
       }
       initialSceneStateRef.current = null;

--- a/components/three/factories.ts
+++ b/components/three/factories.ts
@@ -27,6 +27,7 @@ export type GradientMaterialUniforms = {
   uColor2: { value: Color };
   uColor3: { value: Color };
   uColor4: { value: Color };
+  uOpacity: { value: number };
   uTime: { value: number };
   uAmp: { value: number };
   uFreq: { value: number };
@@ -42,6 +43,7 @@ const vertexShader = /* glsl */ `
   uniform float uAmp;
   uniform float uFreq;
   uniform float uNoiseScale;
+  uniform float uOpacity;
 
   varying vec3 vWorldPos;
   varying vec3 vNormal;
@@ -139,6 +141,7 @@ const fragmentShader = /* glsl */ `
   uniform vec3 uColor2;
   uniform vec3 uColor3;
   uniform vec3 uColor4;
+  uniform float uOpacity;
 
   varying vec3 vWorldPos;
   varying vec3 vNormal;
@@ -167,35 +170,33 @@ const fragmentShader = /* glsl */ `
     float rim = pow(1.0 - max(dot(normal, viewDir), 0.0), 2.2) * 0.35;
 
     vec3 colour = diffuseColor + specular * 0.12 + rim;
-    gl_FragColor = vec4(clamp(colour, 0.0, 1.0), 1.0);
+    gl_FragColor = vec4(clamp(colour, 0.0, 1.0), clamp(uOpacity, 0.0, 1.0));
   }
 `;
 
 const createGradientMaterial = () => {
   const material = new ShaderMaterial({
-  uniforms: {
-    uColor1: { value: new Color("#f9d7fb") },
-    uColor2: { value: new Color("#f3f6c8") },
-    uColor3: { value: new Color("#a8f0d6") },
-    uColor4: { value: new Color("#a1c8ff") },
-    uTime: { value: 0 },
-    uAmp: { value: 0 },
-    uFreq: { value: 1.25 },
-    uNoiseScale: { value: 0 },
-  },
-  vertexShader,
-  fragmentShader,
-}) as GradientMaterial;
+    uniforms: {
+      uColor1: { value: new Color("#f9d7fb") },
+      uColor2: { value: new Color("#f3f6c8") },
+      uColor3: { value: new Color("#a8f0d6") },
+      uColor4: { value: new Color("#a1c8ff") },
+      uOpacity: { value: 1 },
+      uTime: { value: 0 },
+      uAmp: { value: 0 },
+      uFreq: { value: 1.25 },
+      uNoiseScale: { value: 0 },
+    },
+    vertexShader,
+    fragmentShader,
+    transparent: true,
+    depthWrite: false,
+  }) as GradientMaterial;
 
-// ---- aliases de compatibilidade (evita crash quando trocar nomes) ----
-const u: any = material.uniforms;
-if (!u.uNoiseAmp && u.uAmp) u.uNoiseAmp = u.uAmp;
-if (!u.uNoiseFreq && u.uFreq) u.uNoiseFreq = u.uFreq;
-
-
-
-  material.transparent = false;
-  material.depthWrite = true;
+  // ---- aliases de compatibilidade (evita crash quando trocar nomes) ----
+  const u: any = material.uniforms;
+  if (!u.uNoiseAmp && u.uAmp) u.uNoiseAmp = u.uAmp;
+  if (!u.uNoiseFreq && u.uFreq) u.uNoiseFreq = u.uFreq;
 
   return material;
 };

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -72,6 +72,7 @@ sceneObjects.materials.forEach((m) => {
   // se ainda não existir, cria com defaults
   if (!u.uAmp) u.uAmp = { value: 0 };
   if (!u.uFreq) u.uFreq = { value: 1.0 };
+  if (!u.uOpacity) u.uOpacity = { value: 1 };
 });
 
   scene.add(sceneObjects.group);
@@ -87,8 +88,13 @@ sceneObjects.materials.forEach((m) => {
     pointer: { x: 0, y: 0 },
     pointerDriver: "device",
     manualPointer: { x: 0, y: 0 },
+    opacity: 1,
     ready: false,
   };
+
+  sceneObjects.materials.forEach((material) => {
+    material.uniforms.uOpacity.value = initialState.opacity;
+  });
 
   const eventTarget = new EventTarget();
 
@@ -320,6 +326,17 @@ sceneObjects.materials.forEach((m) => {
         pointer: { x: source.x, y: source.y },
       };
       changed = true;
+    }
+
+    if (typeof partial.opacity === "number") {
+      const nextOpacity = clamp(partial.opacity, 0, 1);
+      if (nextOpacity !== state.opacity) {
+        nextState = { ...nextState, opacity: nextOpacity };
+        sceneObjects.materials.forEach((material) => {
+          material.uniforms.uOpacity.value = nextOpacity;
+        });
+        changed = true;
+      }
     }
 
     state = nextState;

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -100,6 +100,7 @@ export type ThreeAppState = {
   pointer: PointerTarget;
   pointerDriver: PointerDriver;
   manualPointer: PointerTarget;
+  opacity: number;
   ready: boolean;
 };
 


### PR DESCRIPTION
## Summary
- add a uOpacity uniform to the custom Three.js materials and shaders and enable transparent rendering
- store and propagate opacity in the Three app state so materials update when the value changes
- adjust page and navigation overlay state updates to apply the new opacity controls per view

## Testing
- npm run verify:three

------
https://chatgpt.com/codex/tasks/task_e_68dcb8c24750832f8841750463307267