### PR TITLE
Adjust canvas z-index layering

### DIFF
--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -39,7 +39,7 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
   return (
     <div
       className={classNames(
-        "pointer-events-none fixed inset-0 -z-50 overflow-visible transition-opacity duration-700",
+        "pointer-events-none fixed inset-0 z-0 overflow-visible transition-opacity duration-700",
         isVisible ? "opacity-100" : "opacity-0",
       )}
       aria-hidden={!isVisible}


### PR DESCRIPTION
## Summary
- update the Three.js canvas root wrapper to use a non-negative z-index so it renders above the background while remaining below the main content

## Testing
- npm run dev
- Manually verified the homepage renders with the canvas behind the content in both light and dark themes


------
https://chatgpt.com/codex/tasks/task_e_68dcbab88764832f817e13b6e164b8cb