### PR TITLE
Use ribbon and ripple helpers for top geometries

### DIFF
--- a/components/three/factories.ts
+++ b/components/three/factories.ts
@@ -309,7 +309,7 @@ const createRibbonGeometry = () => {
 };
 
 const createRippleSphereGeometry = () => {
-  const geometry = new SphereGeometry(0.64, 6);
+  const geometry = new SphereGeometry(0.64, 96, 96);
   geometry.computeVertexNormals();
   geometry.computeBoundingSphere();
   return geometry;
@@ -361,27 +361,10 @@ export const createGeometries = () => {
   });
 
   // 1) S-worm superior esquerdo (curva Catmull)
-  const wave = new TubeGeometry(
-    new CatmullRomCurve3(
-      [
-        new Vector3(-1.35,  0.98, 0.00),
-        new Vector3(-0.78,  0.98, 0.00),
-        new Vector3(-0.38,  0.72, 0.00),
-        new Vector3(-0.92,  0.38, 0.00),
-        new Vector3(-1.48,  0.12, 0.00),
-      ],
-      false,
-      "centripetal",
-      0.52
-    ),
-    540,       // tubularSegments
-    0.12,      // tube radius (espessura)
-    64,        // radialSegments
-    false
-  );
+  const wave = createRibbonGeometry();
 
   // 2) Esfera pequena superior
-  const sphere = new SphereGeometry(0.16, 96, 96);
+  const sphere = createRippleSphereGeometry();
 
   return {
     torus270A,


### PR DESCRIPTION
## Summary
- reuse the ribbon and ripple geometry factories for the wave and sphere meshes
- smooth the ripple sphere helper so the enlarged orb keeps a high segment count

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7b9dbe20832fb566bfc020d78c5b