### PR TITLE
Remove backdrop blur overlays from page sections

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
     <>
       <Navbar />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
-        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-24 bg-bg/70 backdrop-blur">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-24 bg-bg/70">
           <section className="flex-1 space-y-6">
             <AnimatedText
               as="p"
@@ -108,7 +108,7 @@ export default function AboutPage() {
               </Link>
               <Link
                 href="mailto:hello@duartois.studio"
-                className="inline-flex items-center gap-2 rounded-full border border-fg/20 bg-bg/80 px-6 py-3 text-sm font-semibold text-fg shadow-[0_18px_40px_-24px_rgba(0,0,0,0.55)] backdrop-blur transition hover:-translate-y-0.5 hover:border-fg/35"
+                className="inline-flex items-center gap-2 rounded-full border border-fg/20 bg-bg/80 px-6 py-3 text-sm font-semibold text-fg shadow-[0_18px_40px_-24px_rgba(0,0,0,0.55)] transition hover:-translate-y-0.5 hover:border-fg/35"
               >
                 <span>{t("about.cta.contact")}</span>
               </Link>
@@ -117,7 +117,7 @@ export default function AboutPage() {
           <section className="flex flex-1 justify-center lg:justify-end">
             <div className="relative flex h-[22rem] w-[22rem] max-w-full items-center justify-center">
               <div
-                className="pointer-events-none absolute inset-0 -z-20 rounded-full border border-fg/10 bg-[radial-gradient(circle_at_30%_25%,rgba(255,223,245,0.45)_0%,rgba(205,231,255,0.25)_45%,transparent_78%)] shadow-[0_35px_90px_-45px_rgba(0,0,0,0.65)] backdrop-blur"
+                className="pointer-events-none absolute inset-0 -z-20 rounded-full border border-fg/10 bg-[radial-gradient(circle_at_30%_25%,rgba(255,223,245,0.45)_0%,rgba(205,231,255,0.25)_45%,transparent_78%)] shadow-[0_35px_90px_-45px_rgba(0,0,0,0.65)]"
                 aria-hidden
               />
               <div className="pointer-events-none absolute inset-[-6%] -z-10 animate-[spin_24s_linear_infinite] rounded-full border border-transparent border-t-accent2-300/50 border-b-accent1-200/50" aria-hidden />

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -33,7 +33,7 @@ export default function ContactPage() {
     <>
       <Navbar />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
-        <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70 backdrop-blur">
+        <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70">
           <div className="space-y-4">
             <AnimatedText
               as="h1"
@@ -54,7 +54,7 @@ export default function ContactPage() {
           </div>
           <form
             onSubmit={handleSubmit}
-            className="w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)] backdrop-blur"
+            className="w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)]"
           >
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
     <>
       <Navbar />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
-        <section className="flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32 bg-bg/70 backdrop-blur">
+        <section className="flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32 bg-bg/70">
           <div className="flex w-full max-w-3xl flex-col items-center gap-8 sm:gap-10">
             <AnimatedText
               as="span"

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -74,7 +74,7 @@ export default function WorkPage() {
     <>
       <Navbar />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
-        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20 bg-bg/70 backdrop-blur">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 py-24 lg:flex-row lg:items-center lg:gap-20 bg-bg/70">
           <section className="lg:w-1/2">
             <AnimatedText
               as="p"
@@ -131,7 +131,7 @@ export default function WorkPage() {
           </section>
           <section className="relative flex w-full flex-1 items-center justify-center">
             <div
-              className="relative aspect-[4/3] w-full max-w-xl overflow-hidden rounded-3xl border border-fg/15 bg-bg/80 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.6)] backdrop-blur"
+              className="relative aspect-[4/3] w-full max-w-xl overflow-hidden rounded-3xl border border-fg/15 bg-bg/80 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.6)]"
               role="img"
               aria-label={t(`work.projects.${activeProject}.previewAlt`)}
             >


### PR DESCRIPTION
## Summary
- remove the backdrop blur from the home hero overlay to keep the canvas sharp
- stop applying backdrop blur in the work page layout and preview card
- clear backdrop blur styling from the about and contact page containers and call-to-action elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8df667f0832f8d03ec58481ce688