### PR TITLE
Add theme-aware matcap switching for signature shapes

### DIFF
--- a/app/helpers/matcap.ts
+++ b/app/helpers/matcap.ts
@@ -1,10 +1,23 @@
 import * as THREE from "three";
 
+const textureCache = new Map<string, Promise<THREE.Texture>>();
+
 export async function loadMatcap(url: string) {
-  const loader = new THREE.TextureLoader();
-  const tex = await new Promise<THREE.Texture>((res, rej) => {
-    loader.load(url, res, undefined, rej);
-  });
-  tex.colorSpace = THREE.SRGBColorSpace;
-  return tex;
+  if (!textureCache.has(url)) {
+    const loader = new THREE.TextureLoader();
+    const promise = new Promise<THREE.Texture>((resolve, reject) => {
+      loader.load(
+        url,
+        (texture) => {
+          texture.colorSpace = THREE.SRGBColorSpace;
+          resolve(texture);
+        },
+        undefined,
+        reject,
+      );
+    });
+    textureCache.set(url, promise);
+  }
+
+  return textureCache.get(url)!;
 }

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -55,7 +55,7 @@ export const initScene = async ({
 
   const effectivePalette = ensurePalette(palette, theme);
   const baseVariant = cloneVariant(variantMapping[initialVariant]);
-  const shapes = await addDuartoisSignatureShapes(scene, baseVariant);
+  const shapes = await addDuartoisSignatureShapes(scene, baseVariant, theme);
   const shapeMeshes = Object.values(shapes.meshes);
   const shapesGroup = shapes.group;
   const updateMeshesOpacity = (opacity: number) => {
@@ -231,6 +231,7 @@ export const initScene = async ({
 
     if (partial.theme && partial.theme !== state.theme) {
       const nextPalette = partial.palette ?? getDefaultPalette(partial.theme);
+      shapes.applyTheme(partial.theme);
       nextState = {
         ...nextState,
         theme: partial.theme,


### PR DESCRIPTION
## Summary
- extend the Duartois signature shape factory to accept an initial theme, expose an applyTheme helper, and use the black matcap when dark mode is active
- cache matcap textures so repeated theme switches reuse the same assets
- propagate theme changes from initScene so toggling state updates the existing meshes

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dd8ed09100832f89e57c704721b1b3