### PR TITLE
Remove duplicate geometry helpers in addShapes

### DIFF
--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -22,22 +22,6 @@ const SHAPE_ORDER: ShapeId[] = [
 ];
 
 
-const COLOR_SPRING = "#78ffd1";
-const COLOR_AZURE = "#99b9ff";
-const COLOR_LIME = "#f0ffa6";
-const COLOR_FLAMINGO = "#ffb3f2";
-const DARK_THEME_COLOR = "#2b2b33";
-
-const GRADIENT_STOPS: Record<ShapeId, readonly string[]> = {
-  torusSpringAzure: [COLOR_SPRING, COLOR_AZURE],
-  waveSpringLime: [COLOR_SPRING, COLOR_LIME],
-  semiLimeFlamingo: [COLOR_LIME, COLOR_FLAMINGO],
-  torusFlamingoLime: [COLOR_FLAMINGO, COLOR_LIME],
-  semiFlamingoAzure: [COLOR_FLAMINGO, COLOR_AZURE],
-  sphereFlamingoSpring: [COLOR_FLAMINGO, COLOR_SPRING],
-};
-
-
 const ROTATION_SPEEDS: Record<ShapeId, { x: number; y: number }> = {
   torusSpringAzure: { x: 0.0035, y: 0.0042 },
   waveSpringLime: { x: 0.0026, y: 0.0034 },
@@ -168,12 +152,6 @@ class CircularArcCurve extends THREE.Curve<THREE.Vector3> {
   }
 }
 
-const THICKNESS = 0.46;
-const TORUS_RADIUS = 1.72;
-const TORUS_RADIAL_SEGMENTS = 128;
-const TORUS_TUBULAR_SEGMENTS = 192;
-
-
 class WaveCurve extends THREE.Curve<THREE.Vector3> {
   private readonly halfLength: number;
 
@@ -234,9 +212,6 @@ const createPartialTorusGeometry = (arc: number) =>
     TORUS_RADIAL_SEGMENTS,
   );
 
-const createPartialTorusGeometry = (arc: number) =>
-  new THREE.TorusGeometry(TORUS_RADIUS, THICKNESS, TORUS_RADIAL_SEGMENTS, TORUS_TUBULAR_SEGMENTS, arc);
-
 
 export async function addDuartoisSignatureShapes(
   scene: THREE.Scene,
@@ -249,8 +224,6 @@ export async function addDuartoisSignatureShapes(
 
   const waveCurve = new WaveCurve(3.8, 0.74);
 
-  const waveCurve = new WaveCurve(5, 1.12);
-
   const meshes: Record<ShapeId, THREE.Mesh> = {
     torusSpringAzure: new THREE.Mesh(
       applyGradientToGeometry(
@@ -262,11 +235,7 @@ export async function addDuartoisSignatureShapes(
     ),
     waveSpringLime: new THREE.Mesh(
       applyGradientToGeometry(
-
         createRoundedTubeGeometry(waveCurve, 280, 88),
-
-        new THREE.TubeGeometry(waveCurve, 320, THICKNESS, 72, false),
-
         GRADIENT_STOPS.waveSpringLime,
         GRADIENT_AXES.waveSpringLime,
       ),


### PR DESCRIPTION
## Summary
- remove duplicate color, gradient, and geometry constants from the signature shape helpers
- keep a single implementation of the partial torus and wave curve helpers
- ensure the waveSpringLime mesh applies gradients to the intended rounded tube geometry

## Testing
- NEXT_TELEMETRY_DISABLED=1 npm run build *(fails: scripts/verify-three-core-only flags the existing three/examples import)*

------
https://chatgpt.com/codex/tasks/task_e_68dda2c0646c832f9b7efc0437970b34