### PR TITLE
Update light theme colors to match new mockup palette

### DIFF
--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -54,12 +54,12 @@ export default function NavOverlay({
   const { t } = useTranslation("common");
   const overlayPalette = useMemo<GradientPalette>(
     () => [
-      ["#ff6bc2", "#ff92d8", "#ffbdf0", "#ffe8ff"],
-      ["#89d9ff", "#a2e3ff", "#c0edff", "#dcf7ff"],
-      ["#78ff81", "#8eff97", "#aaffb4", "#c8ffd2"],
-      ["#f1ff6b", "#f6ff8e", "#fbffb4", "#ffffd8"],
-      ["#ff6bc2", "#89d9ff", "#78ff81", "#f1ff6b"],
-      ["#ffe9ff", "#e2f7ff", "#e2ffe8", "#ffffdf"],
+      ["#ff5c82", "#ff85a1", "#ffb6c7", "#ffdee6"],
+      ["#85b9ff", "#a4caff", "#c8e0ff", "#e7f1ff"],
+      ["#71ff81", "#94ffa0", "#bfffc6", "#e3ffe6"],
+      ["#f0ff66", "#f4ff8c", "#f8ffba", "#fcffe0"],
+      ["#ff5c82", "#85b9ff", "#71ff81", "#f0ff66"],
+      ["#ffeff2", "#f3f8ff", "#f1fff2", "#fefff0"],
     ],
     [],
   );

--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -31,10 +31,10 @@ const ROTATION_SPEEDS: Record<ShapeId, { x: number; y: number }> = {
   sphereFlamingoSpring: { x: 0.0028, y: 0.0031 },
 };
 
-const COLOR_SPRING = "#78ffd1";
-const COLOR_AZURE = "#99b9ff";
-const COLOR_LIME = "#f0ffa6";
-const COLOR_FLAMINGO = "#ffb3f2";
+const COLOR_SPRING = "#71ff81";
+const COLOR_AZURE = "#85b9ff";
+const COLOR_LIME = "#f0ff66";
+const COLOR_FLAMINGO = "#ff5c82";
 const DARK_THEME_COLOR = "#2b2b33";
 
 const GRADIENT_STOPS: Record<ShapeId, readonly string[]> = {

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -62,11 +62,11 @@ export const variantMapping: Record<VariantName, VariantState> = {
 };
 
 export const LIGHT_THEME_PALETTE: GradientPalette = [
-  ["#78ffd1", "#78ffd1", "#99ffea", "#99ffea"],
-  ["#99b9ff", "#a4c3ff", "#b4d2ff", "#c4e0ff"],
-  ["#f0ffa6", "#f3ffb5", "#f6ffc6", "#f9ffd7"],
-  ["#ffb3f2", "#ffc0f4", "#ffd2f8", "#ffe3fb"],
-  ["#78ffd1", "#99b9ff", "#f0ffa6", "#ffb3f2"],
+  ["#71ff81", "#94ffa0", "#bfffc6", "#e3ffe6"],
+  ["#85b9ff", "#a4caff", "#c8e0ff", "#e7f1ff"],
+  ["#f0ff66", "#f4ff8c", "#f8ffba", "#fcffe0"],
+  ["#ff5c82", "#ff85a1", "#ffb6c7", "#ffdee6"],
+  ["#71ff81", "#85b9ff", "#f0ff66", "#ff5c82"],
 ];
 
 export const DARK_THEME_PALETTE: GradientPalette = [


### PR DESCRIPTION
## Summary
- update the Three.js shape colors to use the new mockup hex values
- refresh the light theme gradient palette for the scene and overlay to keep tones consistent

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ddadb33ca0832fa5881ada4737d7f1