### PR TITLE
Add adjustable brightness to Three scene

### DIFF
--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -8,6 +8,7 @@ import {
   createStateSnapshot,
 } from "./debug-helpers";
 import {
+  DEFAULT_BRIGHTNESS,
   type GradientPalette,
   type StateUpdater,
   type ThreeAppHandle,
@@ -56,6 +57,7 @@ export const initScene = async ({
   const effectivePalette = ensurePalette(palette, theme);
   const baseVariant = cloneVariant(variantMapping[initialVariant]);
   const shapes = await addDuartoisSignatureShapes(scene, baseVariant, theme);
+  shapes.setBrightness(DEFAULT_BRIGHTNESS);
   const shapeMeshes = Object.values(shapes.meshes);
   const shapesGroup = shapes.group;
   type MaterialWithOpacity = THREE.Material & {
@@ -96,6 +98,7 @@ export const initScene = async ({
     pointerDriver: "device",
     manualPointer: { x: 0, y: 0 },
     opacity: 1,
+    brightness: DEFAULT_BRIGHTNESS,
     ready: false,
   };
 
@@ -245,6 +248,15 @@ export const initScene = async ({
         palette: nextPalette,
       };
       changed = true;
+    }
+
+    if (typeof partial.brightness === "number") {
+      const nextBrightness = clamp(partial.brightness, 0.5, 2);
+      if (nextBrightness !== state.brightness) {
+        shapes.setBrightness(nextBrightness);
+        nextState = { ...nextState, brightness: nextBrightness };
+        changed = true;
+      }
     }
 
     if (typeof partial.parallax === "boolean" && partial.parallax !== state.parallax) {

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -88,6 +88,8 @@ export const DARK_THEME_PALETTE: GradientPalette = [
 
 export type ThemeName = "light" | "dark";
 
+export const DEFAULT_BRIGHTNESS = 1.2;
+
 export type ThreeAppState = {
   variantName: VariantName;
   variant: VariantState;
@@ -100,6 +102,7 @@ export type ThreeAppState = {
   pointerDriver: PointerDriver;
   manualPointer: PointerTarget;
   opacity: number;
+  brightness: number;
   ready: boolean;
 };
 


### PR DESCRIPTION
## Summary
- add a default brightness value to the Three app state
- scale lights and emissive intensity in the signature shapes based on the current brightness
- initialize the scene brightness and propagate updates through the Three app handle

## Testing
- npm run lint *(fails: npm command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb41e48cc832fa1316e9d84140361