### PR TITLE
Ensure Three.js canvas spans the background

### DIFF
--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -49,7 +49,9 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
           className="pointer-events-none absolute inset-0 z-10 bg-repeat bg-center [background-size:220px] opacity-40 mix-blend-soft-light dark:opacity-30"
           style={{ backgroundImage: `url(${noiseUrl.src})` }}
         />
-        <CoreCanvas />
+        <div className="absolute inset-0 z-0">
+          <CoreCanvas />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap the Three.js CoreCanvas component in an absolutely positioned container so it fills the viewport and sits beneath overlays
- keep the noise overlay layered above the canvas to preserve the intended blend effect

## Testing
- npm run dev (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68ddb9decbbc832fac023bb475b588ee