### PR TITLE
Adjust noise overlay and pastelize 3D shapes

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
+import noiseUrl from "@/public/noise.png";
 import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
@@ -37,9 +38,14 @@ export default function AppShell({ children }: AppShellProps) {
     <div className="relative min-h-screen w-full overflow-hidden">
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
+      <div
+        className="pointer-events-none fixed inset-0 z-10 bg-repeat bg-center opacity-40 mix-blend-soft-light [background-size:220px] dark:opacity-30"
+        style={{ backgroundImage: `url(${noiseUrl.src})` }}
+        aria-hidden
+      />
       {canRenderContent ? (
         <div
-          className={`relative z-10 flex min-h-screen w-full flex-col transition-opacity duration-700 ${
+          className={`relative z-20 flex min-h-screen w-full flex-col transition-opacity duration-700 ${
             isContentVisible
               ? "visible opacity-100"
               : "pointer-events-none invisible opacity-0"

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -3,8 +3,6 @@
 import classNames from "classnames";
 import { useEffect, useState } from "react";
 
-import noiseUrl from "@/public/noise.png";
-
 import CoreCanvas from "./CoreCanvas";
 
 interface CanvasRootProps {
@@ -45,10 +43,6 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
       aria-hidden={!isVisible}
     >
       <div className="relative h-full w-full">
-        <div
-          className="pointer-events-none absolute inset-0 z-10 bg-repeat bg-center [background-size:220px] opacity-40 mix-blend-soft-light dark:opacity-30"
-          style={{ backgroundImage: `url(${noiseUrl.src})` }}
-        />
         <div className="absolute inset-0 z-0">
           <CoreCanvas />
         </div>

--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -41,6 +41,8 @@ const COLOR_AZURE = "#85b9ff";
 const COLOR_LIME = "#f0ff66";
 const COLOR_FLAMINGO = "#ff5c82";
 const DARK_THEME_COLOR = "#2b2b33";
+const PASTEL_TARGET = new THREE.Color("#ffffff");
+const PASTEL_INTENSITY = 0.35;
 
 const GRADIENT_STOPS: Record<ShapeId, readonly string[]> = {
   torusSpringAzure: [COLOR_AZURE, COLOR_SPRING],
@@ -118,7 +120,7 @@ const applyGradientToGeometry = (
     const localT = scaled - index;
     const from = stopColors[index];
     const to = stopColors[nextIndex];
-    const color = from.clone().lerp(to, localT);
+    const color = from.clone().lerp(to, localT).lerp(PASTEL_TARGET, PASTEL_INTENSITY);
     colors[i * 3] = color.r;
     colors[i * 3 + 1] = color.g;
     colors[i * 3 + 2] = color.b;


### PR DESCRIPTION
## Summary
- move the noise texture overlay to the app shell so it spans the entire background layer stack
- ensure textual content stays above the noise layer while keeping the 3D canvas underneath
- blend the existing 3D palette colors toward white to give the shapes a pastel look without changing the base constants

## Testing
- not run (blocked by interactive lint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68ddbe59f878832f9962def2789413e4