### PR TITLE
Move noise overlay to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
 import { getDefaultPalette } from "../components/three/types";
+import noiseUrl from "@/public/noise.png";
 
 export default function HomePage() {
   const { t } = useTranslation("common");
@@ -25,6 +26,11 @@ export default function HomePage() {
   return (
     <>
       <Navbar />
+      <div
+        className="pointer-events-none fixed inset-0 z-[9999] bg-repeat bg-center opacity-40 mix-blend-soft-light [background-size:220px] dark:opacity-30"
+        style={{ backgroundImage: `url(${noiseUrl.src})` }}
+        aria-hidden
+      />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <section className="flex min-h-screen flex-col items-center justify-center px-6 py-24 text-center sm:px-10 md:py-32 bg-bg/70">
           <div className="flex w-full max-w-3xl flex-col items-center gap-8 sm:gap-10">

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,7 +2,6 @@
 
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
-import noiseUrl from "@/public/noise.png";
 import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
@@ -38,11 +37,6 @@ export default function AppShell({ children }: AppShellProps) {
     <div className="relative min-h-screen w-full overflow-hidden">
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
-      <div
-        className="pointer-events-none fixed inset-0 z-[9999] bg-repeat bg-center opacity-40 mix-blend-soft-light [background-size:220px] dark:opacity-30"
-        style={{ backgroundImage: `url(${noiseUrl.src})` }}
-        aria-hidden
-      />
       {canRenderContent ? (
         <div
           className={`relative z-20 flex min-h-screen w-full flex-col transition-opacity duration-700 ${


### PR DESCRIPTION
## Summary
- remove the global noise overlay from the shared application shell
- render the noise overlay only on the home page to keep the visual effect localized

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc1293410832faba660d8d32cb0c8