### PR TITLE
Adjust light theme tone mapping and lighting

### DIFF
--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -353,11 +353,11 @@ export async function addDuartoisSignatureShapes(
     currentTheme = theme;
     const isDark = theme === "dark";
 
-    const baseAmbient = isDark ? 0.38 : 0.30;
-    const baseHemisphere = isDark ? 0.8 : 0.7;
-    const baseKey = isDark ? 0.45 : 0.35;
-    const baseFill = isDark ? 0.34 : 0.26;
-    const baseRim = isDark ? 0.4 : 0.3;
+    const baseAmbient = isDark ? 0.38 : 0.46;
+    const baseHemisphere = isDark ? 0.8 : 0.95;
+    const baseKey = isDark ? 0.45 : 0.52;
+    const baseFill = isDark ? 0.34 : 0.42;
+    const baseRim = isDark ? 0.4 : 0.5;
     const baseEmissive = 0.0; // não vamos “tintar” com emissive
 
 

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -53,7 +53,7 @@ export const initScene = async ({
   // === pastel/filmic renderer ===
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   // menos brilho no tema claro, levemente mais no escuro
-  renderer.toneMappingExposure = theme === "light" ? 0.85 : 1.05;
+  renderer.toneMappingExposure = theme === "light" ? 1.1 : 1.05;
   // sombras desligadas para evitar contorno duro
   renderer.shadowMap.enabled = false;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;


### PR DESCRIPTION
## Summary
- increase the tone mapping exposure used in the light theme renderer
- brighten all light sources applied to shapes when the light theme is active

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ddf1868b0c832fb8b53750f8a2693c