### PR TITLE
refactor: refresh palette

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -120,7 +120,7 @@ export default function AboutPage() {
                 className="pointer-events-none absolute inset-0 -z-20 rounded-full border border-fg/10 bg-fg/10 shadow-[0_35px_90px_-45px_rgba(0,0,0,0.65)]"
                 aria-hidden
               />
-              <div className="pointer-events-none absolute inset-[-6%] -z-10 animate-[spin_24s_linear_infinite] rounded-full border border-transparent border-t-accent2-300/50 border-b-accent1-200/50" aria-hidden />
+              <div className="pointer-events-none absolute inset-[-6%] -z-10 animate-[spin_24s_linear_infinite] rounded-full border border-transparent border-t-azure/50 border-b-flamingo/50" aria-hidden />
               <div className="pointer-events-none absolute inset-[16%] rounded-full border border-fg/10 opacity-60" aria-hidden />
               <div className="relative h-56 w-56 overflow-hidden rounded-full border border-fg/15 shadow-[0_28px_60px_-30px_rgba(0,0,0,0.65)]">
                 <Image
@@ -132,8 +132,8 @@ export default function AboutPage() {
                   priority
                 />
               </div>
-              <div className="pointer-events-none absolute -left-6 top-0 h-20 w-20 rounded-full bg-accent2-200/15 blur-2xl" aria-hidden />
-              <div className="pointer-events-none absolute -bottom-10 right-0 h-24 w-24 rounded-full bg-accent1-300/20 blur-3xl" aria-hidden />
+              <div className="pointer-events-none absolute -left-6 top-0 h-20 w-20 rounded-full bg-azure/15 blur-2xl" aria-hidden />
+              <div className="pointer-events-none absolute -bottom-10 right-0 h-24 w-24 rounded-full bg-flamingo/20 blur-3xl" aria-hidden />
               <div className="pointer-events-none absolute -bottom-6 -left-10 h-28 w-28">
                 <div className="relative h-full w-full">
                   <Image

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,47 +1,47 @@
 @import "tailwindcss";
 
 :root {
-  --color-bg: 240 242 245;
-  --color-fg: 34 38 44;
-  --color-muted: 112 118 140;
-  --glow-lilac: 255 107 194;
-  --glow-mint: 137 217 255;
-  --glow-spring: 120 255 129;
-  --glow-lime: 241 255 107;
-  --nav-overlay-surface-color: rgb(var(--color-bg) / 0.94);
-  --nav-overlay-blob-a-color: rgb(var(--color-fg) / 0.08);
-  --nav-overlay-blob-b-color: rgb(var(--color-fg) / 0.06);
-  --nav-overlay-blob-c-color: rgb(var(--color-fg) / 0.04);
+  --color-bg: 252 247 251;
+  --color-fg: 43 43 51;
+  --color-muted: 118 118 142;
+  --glow-flamingo: 255 179 194;
+  --glow-azure: 153 185 255;
+  --glow-spring: 120 255 209;
+  --glow-lime: 240 255 166;
+  --nav-overlay-surface-color: rgb(var(--color-bg) / 0.95);
+  --nav-overlay-blob-a-color: rgb(var(--glow-flamingo) / 0.22);
+  --nav-overlay-blob-b-color: rgb(var(--glow-azure) / 0.18);
+  --nav-overlay-blob-c-color: rgb(var(--glow-spring) / 0.16);
 }
 
 /* Modo claro */
 :root[data-theme="light"], :root.light {
-  --color-bg: 240 242 245;
-  --color-fg: 34 38 44;
-  --color-muted: 112 118 140;
-  --glow-lilac: 255 107 194;
-  --glow-mint: 137 217 255;
-  --glow-spring: 120 255 129;
-  --glow-lime: 241 255 107;
-  --nav-overlay-surface-color: rgb(var(--color-bg) / 0.94);
-  --nav-overlay-blob-a-color: rgb(var(--color-fg) / 0.08);
-  --nav-overlay-blob-b-color: rgb(var(--color-fg) / 0.06);
-  --nav-overlay-blob-c-color: rgb(var(--color-fg) / 0.04);
+  --color-bg: 252 247 251;
+  --color-fg: 43 43 51;
+  --color-muted: 118 118 142;
+  --glow-flamingo: 255 179 194;
+  --glow-azure: 153 185 255;
+  --glow-spring: 120 255 209;
+  --glow-lime: 240 255 166;
+  --nav-overlay-surface-color: rgb(var(--color-bg) / 0.95);
+  --nav-overlay-blob-a-color: rgb(var(--glow-flamingo) / 0.22);
+  --nav-overlay-blob-b-color: rgb(var(--glow-azure) / 0.18);
+  --nav-overlay-blob-c-color: rgb(var(--glow-spring) / 0.16);
 }
 
 /* Modo escuro */
 :root[data-theme="dark"], :root.dark {
-  --color-bg: 32 35 44;
-  --color-fg: 245 245 252;
-  --color-muted: 178 181 204;
-  --glow-lilac: 185 79 151;
-  --glow-mint: 64 126 179;
-  --glow-spring: 64 156 104;
-  --glow-lime: 140 143 70;
+  --color-bg: 43 43 51;
+  --color-fg: 240 245 255;
+  --color-muted: 178 184 206;
+  --glow-flamingo: 227 128 156;
+  --glow-azure: 118 155 220;
+  --glow-spring: 104 205 168;
+  --glow-lime: 190 215 130;
   --nav-overlay-surface-color: rgb(var(--color-bg) / 0.92);
-  --nav-overlay-blob-a-color: rgb(var(--color-fg) / 0.12);
-  --nav-overlay-blob-b-color: rgb(var(--color-fg) / 0.1);
-  --nav-overlay-blob-c-color: rgb(var(--color-fg) / 0.08);
+  --nav-overlay-blob-a-color: rgb(var(--glow-flamingo) / 0.26);
+  --nav-overlay-blob-b-color: rgb(var(--glow-azure) / 0.2);
+  --nav-overlay-blob-c-color: rgb(var(--glow-spring) / 0.18);
 }
 
 /* 2) Reset & base */
@@ -71,15 +71,27 @@ html, body {
 
 .btn {
   @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-medium lowercase tracking-[0.08em] transition-[transform,box-shadow,background-color,color] duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
-  @apply shadow-[0_10px_30px_-12px_rgba(112,81,155,0.55)] hover:scale-[1.03] active:scale-[0.97];
+  @apply shadow-[0_10px_30px_-12px_rgba(153,185,255,0.55)] hover:scale-[1.03] active:scale-[0.97];
   background: linear-gradient(
     135deg,
-    rgb(var(--glow-lilac) / 0.95),
-    rgb(var(--glow-mint) / 0.9),
+    rgb(var(--glow-flamingo) / 0.95),
+    rgb(var(--glow-azure) / 0.92),
+    rgb(var(--glow-spring) / 0.9),
     rgb(var(--glow-lime) / 0.85)
   );
   color: rgb(var(--color-fg));
   backdrop-filter: blur(16px);
+}
+.dark .btn,
+:root[data-theme="dark"] .btn {
+  background: linear-gradient(
+    135deg,
+    rgb(var(--glow-flamingo) / 0.38),
+    rgb(var(--glow-azure) / 0.34),
+    rgb(var(--glow-spring) / 0.32),
+    rgb(var(--glow-lime) / 0.3)
+  );
+  @apply shadow-[0_18px_36px_-20px_rgba(18,18,26,0.65)];
 }
 .btn-secondary {
   @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-medium lowercase tracking-[0.08em] transition duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
@@ -95,25 +107,50 @@ html, body {
   @apply inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-medium lowercase tracking-[0.12em] transition-[background-color,box-shadow,transform,color] duration-500 ease-[cubic-bezier(.22,.61,.36,1)];
   background: linear-gradient(
     135deg,
-    rgb(var(--glow-lilac) / 0.45),
-    rgb(var(--glow-mint) / 0.35),
-    rgb(var(--glow-spring) / 0.32)
+    rgb(var(--glow-flamingo) / 0.55),
+    rgb(var(--glow-azure) / 0.45),
+    rgb(var(--glow-spring) / 0.42),
+    rgb(var(--glow-lime) / 0.4)
   );
   color: rgb(var(--color-fg));
   backdrop-filter: blur(22px);
-  box-shadow: 0 10px 30px -12px rgba(62, 44, 102, 0.45);
+  box-shadow: 0 12px 34px -16px rgba(153, 185, 255, 0.32);
 }
 .hero-button:hover,
 .hero-button:focus-visible {
   @apply outline-none;
   background: linear-gradient(
     135deg,
-    rgb(var(--glow-mint) / 0.45),
-    rgb(var(--glow-spring) / 0.4),
-    rgb(var(--glow-lime) / 0.38)
+    rgb(var(--glow-azure) / 0.55),
+    rgb(var(--glow-spring) / 0.5),
+    rgb(var(--glow-lime) / 0.48),
+    rgb(var(--glow-flamingo) / 0.52)
   );
   color: rgb(var(--color-fg));
   transform: translateY(-1px);
+}
+.dark .hero-button,
+:root[data-theme="dark"] .hero-button {
+  background: linear-gradient(
+    135deg,
+    rgb(var(--glow-flamingo) / 0.26),
+    rgb(var(--glow-azure) / 0.24),
+    rgb(var(--glow-spring) / 0.22),
+    rgb(var(--glow-lime) / 0.2)
+  );
+  box-shadow: 0 16px 34px -20px rgba(14, 14, 22, 0.45);
+}
+.dark .hero-button:hover,
+.dark .hero-button:focus-visible,
+:root[data-theme="dark"] .hero-button:hover,
+:root[data-theme="dark"] .hero-button:focus-visible {
+  background: linear-gradient(
+    135deg,
+    rgb(var(--glow-azure) / 0.32),
+    rgb(var(--glow-spring) / 0.3),
+    rgb(var(--glow-lime) / 0.28),
+    rgb(var(--glow-flamingo) / 0.3)
+  );
 }
 .hero-button--ghost {
   background: rgb(var(--color-fg) / 0.08);
@@ -121,7 +158,17 @@ html, body {
 }
 .hero-button--ghost:hover,
 .hero-button--ghost:focus-visible {
-  background: rgb(var(--glow-lilac) / 0.4);
+  background: rgb(var(--glow-flamingo) / 0.4);
+}
+.dark .hero-button--ghost,
+:root[data-theme="dark"] .hero-button--ghost {
+  background: rgb(var(--color-fg) / 0.12);
+}
+.dark .hero-button--ghost:hover,
+.dark .hero-button--ghost:focus-visible,
+:root[data-theme="dark"] .hero-button--ghost:hover,
+:root[data-theme="dark"] .hero-button--ghost:focus-visible {
+  background: rgb(var(--glow-flamingo) / 0.2);
 }
 
 .hero-animate {

--- a/components/NavHeaderContent.tsx
+++ b/components/NavHeaderContent.tsx
@@ -93,7 +93,7 @@ const styles: Record<
   default: {
     container: "flex items-center justify-between gap-6",
     brandLink:
-      "group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-500 dark:hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
+      "group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-lime dark:hover:text-spring focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
     brandPrefix: "text-fg/60 dark:text-fg/70",
     brandSuffix: "text-fg dark:text-fg",
     controlsContainer:
@@ -107,7 +107,7 @@ const styles: Record<
   overlay: {
     container: "flex items-center justify-between gap-6",
     brandLink:
-      "pointer-events-auto group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-brand-400 dark:hover:text-brand-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
+      "pointer-events-auto group inline-flex items-baseline gap-2 text-sm font-semibold uppercase tracking-[0.28em] text-fg transition duration-300 ease-out hover:text-lime dark:hover:text-spring focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg/70",
     brandPrefix: "text-fg/60 dark:text-fg/70",
     brandSuffix: "text-fg dark:text-fg",
     controlsContainer:

--- a/components/WaveUnderline.tsx
+++ b/components/WaveUnderline.tsx
@@ -19,7 +19,7 @@ export function WaveUnderline({
       <span className="relative z-10">{children}</span>
       <span
         aria-hidden
-        className={clsx("mt-2 h-2 overflow-hidden text-brand-400", underlineClassName)}
+        className={clsx("mt-2 h-2 overflow-hidden text-lime", underlineClassName)}
       >
         <span
           className="block h-full w-full bg-repeat-x bg-[length:7.5rem_0.75rem] animate-wave"

--- a/components/icons/ThemeToggleIcons.tsx
+++ b/components/icons/ThemeToggleIcons.tsx
@@ -13,7 +13,7 @@ export function MoonIcon({ className, ...props }: IconProps) {
       aria-hidden
       focusable="false"
       className={clsx(
-        "h-6 w-6 text-accent3-200 drop-shadow-sm transition-transform duration-300 ease-pleasant",
+        "h-6 w-6 text-spring drop-shadow-sm transition-transform duration-300 ease-pleasant",
         className,
       )}
       {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,55 +27,11 @@ const config: Config = {
         bg: "rgb(var(--color-bg) / <alpha-value>)",
         fg: "rgb(var(--color-fg) / <alpha-value>)",
         muted: "rgb(var(--color-muted) / <alpha-value>)",
-        // Rampas pastéis para os novos acentos do tema
-        brand: {
-          50: "#f4ffe7",
-          100: "#e8ffc8",
-          200: "#d4ff9d",
-          300: "#b6f972",
-          400: "#9ae752",
-          500: "#6ecd29",
-          600: "#4da01f",
-          700: "#37781b",
-          800: "#285c18",
-          900: "#1e4715"
-        },
-        accent1: {
-          50: "#fff5fa",
-          100: "#ffe7f2",
-          200: "#ffcee4",
-          300: "#ffafd1",
-          400: "#ff8fbb",
-          500: "#f96aa7",
-          600: "#df4c8b",
-          700: "#b8366d",
-          800: "#8e274f",
-          900: "#6c1d3b"
-        },
-        accent2: {
-          50: "#f9f5ff",
-          100: "#f1e8ff",
-          200: "#e3d4ff",
-          300: "#ceb5ff",
-          400: "#b391f6",
-          500: "#9472dd",
-          600: "#7657bd",
-          700: "#5c4395",
-          800: "#443171",
-          900: "#322456"
-        },
-        accent3: {
-          50: "#e8fffc",
-          100: "#c8fff4",
-          200: "#99f7ea",
-          300: "#6ae7dd",
-          400: "#3ecfd0",
-          500: "#1fb0ba",
-          600: "#188c99",
-          700: "#136d79",
-          800: "#0f535e",
-          900: "#0b4048"
-        }
+        flamingo: "#ffb3c2",
+        azure: "#99b9ff",
+        spring: "#78ffd1",
+        lime: "#f0ffa6",
+        dark: "#2b2b33",
       },
       // sombras e transições suaves
       boxShadow: {


### PR DESCRIPTION
## Summary
- replace the Tailwind theme ramps with the new flamingo, azure, spring, lime, and dark tokens
- refresh global CSS variables and gradients so light/dark modes use the vibrant palette
- update component styles to reference the new color names across the UI

## Testing
- npm run lint *(fails: Next.js prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68de0f021ae0832fb74c633ad4656564