### PR TITLE
Refactor three scene setup handling

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import Navbar from "../../components/Navbar";
 import AnimatedText from "../../components/AnimatedText";
 import Link from "next/link";
@@ -8,20 +7,12 @@ import { Trans, useTranslation } from "react-i18next";
 import Image from "next/image";
 import "../i18n/config";
 
-import { getDefaultPalette } from "../../components/three/types";
+import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
 
 export default function AboutPage() {
   const { t } = useTranslation("common");
 
-  useEffect(() => {
-    window.__THREE_APP__?.setState((previous) => ({
-      variantName: "about",
-      palette: getDefaultPalette(previous.theme),
-      parallax: true,
-      hovered: false,
-      opacity: 0.3,
-    }));
-  }, []);
+  useThreeSceneSetup("about");
 
   return (
     <>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,26 +1,18 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 import Navbar from "../../components/Navbar";
 import AnimatedText from "../../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
-import { getDefaultPalette } from "../../components/three/types";
+import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
 
 export default function ContactPage() {
   const { t } = useTranslation("common");
   const [status, setStatus] = useState<"idle" | "submitted">("idle");
 
-  useEffect(() => {
-    window.__THREE_APP__?.setState((previous) => ({
-      variantName: "contact",
-      palette: getDefaultPalette(previous.theme),
-      parallax: true,
-      hovered: false,
-      opacity: 0.3,
-    }));
-  }, []);
+  useThreeSceneSetup("contact");
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/app/helpers/useThreeSceneSetup.ts
+++ b/app/helpers/useThreeSceneSetup.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { getDefaultPalette, type VariantName } from "@/components/three/types";
+
+type SceneOptions = {
+  opacity?: number;
+  parallax?: boolean;
+  hovered?: boolean;
+  resetOnUnmount?: boolean;
+};
+
+const DEFAULT_OPTIONS = {
+  opacity: 0.3,
+  parallax: true,
+  hovered: false,
+} as const;
+
+const applySceneState = (
+  variantName: VariantName,
+  { opacity, parallax, hovered }: Required<Omit<SceneOptions, "resetOnUnmount">>,
+) => {
+  window.__THREE_APP__?.setState((previous) => ({
+    variantName,
+    palette: getDefaultPalette(previous.theme),
+    parallax,
+    hovered,
+    opacity,
+  }));
+};
+
+export function useThreeSceneSetup(
+  variantName: VariantName,
+  {
+    opacity = DEFAULT_OPTIONS.opacity,
+    parallax = DEFAULT_OPTIONS.parallax,
+    hovered = DEFAULT_OPTIONS.hovered,
+    resetOnUnmount = false,
+  }: SceneOptions = {},
+) {
+  useEffect(() => {
+    applySceneState(variantName, { opacity, parallax, hovered });
+  }, [hovered, opacity, parallax, variantName]);
+
+  useEffect(() => {
+    if (!resetOnUnmount) {
+      return;
+    }
+
+    return () => {
+      applySceneState(variantName, { opacity, parallax, hovered });
+    };
+  }, [hovered, opacity, parallax, resetOnUnmount, variantName]);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
 import Link from "next/link";
 import Navbar from "../components/Navbar";
 import AnimatedText from "../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "./i18n/config";
 
-import { getDefaultPalette } from "../components/three/types";
 import noiseUrl from "@/public/noise.png";
+import { useThreeSceneSetup } from "./helpers/useThreeSceneSetup";
 
 export default function HomePage() {
   const { t } = useTranslation("common");
 
-  useEffect(() => {
-    window.__THREE_APP__?.setState((previous) => ({
-      variantName: "home",
-      palette: getDefaultPalette(previous.theme),
-      parallax: true,
-      hovered: false,
-      opacity: 1,
-    }));
-  }, []);
+  useThreeSceneSetup("home", { opacity: 1 });
 
   return (
     <>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -7,7 +7,8 @@ import AnimatedText from "../../components/AnimatedText";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
-import { getDefaultPalette, type VariantName } from "../../components/three/types";
+import { type VariantName } from "../../components/three/types";
+import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
 
 const projectOrder = ["aurora", "mare", "spectrum"] as const;
 
@@ -38,15 +39,7 @@ export default function WorkPage() {
 
   const activePreview = projectPreviews[activeProject];
 
-  useEffect(() => {
-    window.__THREE_APP__?.setState((previous) => ({
-      variantName: "work",
-      palette: getDefaultPalette(previous.theme),
-      parallax: true,
-      hovered: false,
-      opacity: 0.3,
-    }));
-  }, []);
+  useThreeSceneSetup("work", { resetOnUnmount: true });
 
   useEffect(() => {
     const preview = activePreview;
@@ -58,17 +51,6 @@ export default function WorkPage() {
     });
   }, [activePreview]);
 
-  useEffect(() => {
-    return () => {
-      window.__THREE_APP__?.setState((previous) => ({
-        variantName: "work",
-        palette: getDefaultPalette(previous.theme),
-        parallax: true,
-        hovered: false,
-        opacity: 0.3,
-      }));
-    };
-  }, []);
 
   return (
     <>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,8 +5,7 @@
   "navbar": {
     "open": "Open navigation",
     "close": "Close navigation",
-    "menu": "Menu",
-    "closeMenu": "Close"
+    "menu": "Menu"
   },
   "home": {
     "hero": {

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -5,8 +5,7 @@
   "navbar": {
     "open": "Abrir navegação",
     "close": "Fechar navegação",
-    "menu": "Menu",
-    "closeMenu": "Fechar"
+    "menu": "Menu"
   },
   "home": {
     "hero": {


### PR DESCRIPTION
## Summary
- add a reusable `useThreeSceneSetup` hook to centralize three.js scene initialization logic
- update the home, about, contact, and work pages to use the new hook instead of inline effects
- remove unused `closeMenu` translation entries from the locale files

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68de81947f98832f95cfe48a34bf6d5c