### PR TITLE
Use document.fonts.ready directly in preloader

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -31,7 +31,7 @@ export default function Preloader({ onComplete }: PreloaderProps) {
   useEffect(() => {
     let isCancelled = false;
 
-    const fontsPromise = (typeof document !== "undefined" && "fonts" in document
+    (typeof document !== "undefined" && "fonts" in document
       ? document.fonts.ready.catch(() => undefined)
       : Promise.resolve()
     ).then(() => {


### PR DESCRIPTION
## Summary
- call `document.fonts.ready` directly in the preloader initialization effect
- remove the unused `fontsPromise` variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de89fc1728832fa72b78bb77b09f98