### PR TITLE
Fix stray scene geometry and clean translations

### DIFF
--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -46,7 +46,7 @@ const createFramedVariant = (): VariantState => ({
     scale: [0.75, 0.75, 0.75],
   },
   torusFlamingoLime: {
-    position: [-100.64, -0.62, -0.58],
+    position: [-0.64, -0.62, -0.58],
     rotation: [-0.28, 0.44, 0.92],
     scale: [0.75, 0.75, 0.75],
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -82,9 +82,6 @@
       "ready": "Ready to start!"
     }
   },
-  "experience": {
-    "loadingFallback": "Materializing shapes…"
-  },
   "themeToggle": {
     "ariaLabel": "Switch to the {{theme}} theme",
     "title": "{{theme}} theme",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -81,9 +81,6 @@
       "ready": "Pronto para começar!"
     }
   },
-  "experience": {
-    "loadingFallback": "Materializando formas…"
-  },
   "themeToggle": {
     "ariaLabel": "Alternar para o tema {{theme}}",
     "title": "Tema {{theme}}",


### PR DESCRIPTION
## Summary
- correct the torus variant transform so the home scene no longer spawns a distant duplicate cluster
- drop the unused experience translation entries from both locale files

## Testing
- npm run lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8c0d0e04832fb5b6b4062ae29000