### PR TITLE
Refine three.js scene setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 node_modules
-papackage-lock.json
+package-lock.json
 dist
 .env
 .vscode
 .DS_Store
 .next
+tsconfig.tsbuildinfo

--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -284,16 +284,10 @@ export async function addDuartoisSignatureShapes(
   const orderedMeshes = SHAPE_ORDER.map((id) => meshes[id]);
 
   const ambient = new THREE.AmbientLight(0xffffff, 0.18);
-  const hemisphere = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.7); // sem ground escuro
   const keyLight = new THREE.DirectionalLight(0xffffff, 0.35);
   keyLight.position.set(6, 8, 8);
-  const fillLight = new THREE.DirectionalLight(0xffffff, 0.2);
-  fillLight.position.set(-4, 5, 6);
-  const rimLight = new THREE.DirectionalLight(0xffffff, 0.2);
-  rimLight.position.set(0, -6, -7);
 
-
-  const lights: THREE.Light[] = [ambient, hemisphere, keyLight, fillLight, rimLight];
+  const lights: THREE.Light[] = [ambient, keyLight];
 
   orderedMeshes.forEach((mesh) => {
     mesh.castShadow = false;
@@ -377,33 +371,20 @@ export async function addDuartoisSignatureShapes(
 
     const darkLightSettings = {
       ambient: 0.38,
-      hemisphere: 0.8,
       key: 0.45,
-      fill: 0.34,
-      rim: 0.1,
     } as const;
 
     const lightLightSettings = {
       ambient: 1.5,
-      hemisphere: 0,
       key: 0,
-      fill: 0,
-      rim: 0,
     } as const;
 
     const lightSettings = isDark ? darkLightSettings : lightLightSettings;
 
     ambient.color.set("#ffffff");
     ambient.intensity = lightSettings.ambient * currentBrightness;
-    hemisphere.color.set("#ffffff");
-    hemisphere.groundColor.set("#ffffff");
-    hemisphere.intensity = lightSettings.hemisphere * currentBrightness;
     keyLight.color.set(isDark ? "#ffffff" : "#fff3e0");
     keyLight.intensity = lightSettings.key * currentBrightness;
-    fillLight.color.set(isDark ? "#ffe9ff" : "#f2ffff");
-    fillLight.intensity = lightSettings.fill * currentBrightness;
-    rimLight.color.set(isDark ? "#d8e6ff" : "#ffffff");
-    rimLight.intensity = lightSettings.rim * currentBrightness;
   };
 
   const setBrightness = (value: number) => {

--- a/components/three/factories.ts
+++ b/components/three/factories.ts
@@ -1,12 +1,6 @@
 import { OrthographicCamera } from "three";
 
-import {
-  type GradientPalette,
-  type ThemeName,
-  type VariantState,
-  createVariantState,
-  getDefaultPalette,
-} from "./types";
+import { type GradientPalette, type ThemeName, getDefaultPalette } from "./types";
 
 export const createCamera = () => {
   const aspect = window.innerWidth / window.innerHeight;
@@ -16,8 +10,6 @@ export const createCamera = () => {
   camera.updateProjectionMatrix();
   return camera;
 };
-
-export const cloneVariant = (variant: VariantState) => createVariantState(variant);
 
 export const ensurePalette = (
   palette: GradientPalette | undefined,

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -15,14 +15,11 @@ import {
   type ThreeAppState,
   type ThemeName,
   type VariantName,
+  createVariantState,
   getDefaultPalette,
   variantMapping,
 } from "./types";
-import {
-  cloneVariant,
-  createCamera,
-  ensurePalette,
-} from "./factories";
+import { createCamera, ensurePalette } from "./factories";
 import { addDuartoisSignatureShapes } from "@/components/three/addShapes";
 
 export type InitSceneOptions = {
@@ -43,6 +40,10 @@ export const initScene = async ({
   palette,
   parallax = true,
 }: InitSceneOptions): Promise<ThreeAppHandle> => {
+  if (typeof window !== "undefined") {
+    window.__THREE_APP__?.dispose();
+  }
+
   const renderer = new WebGLRenderer({
     canvas,
     antialias: true,
@@ -62,7 +63,7 @@ export const initScene = async ({
   scene.add(camera);
 
   const effectivePalette = ensurePalette(palette, theme);
-  const baseVariant = cloneVariant(variantMapping[initialVariant]);
+  const baseVariant = createVariantState(variantMapping[initialVariant]);
   const shapes = await addDuartoisSignatureShapes(scene, baseVariant, theme);
   shapes.setBrightness(DEFAULT_BRIGHTNESS);
   const shapeMeshes = Object.values(shapes.meshes);
@@ -95,7 +96,7 @@ export const initScene = async ({
   };
   const initialState: ThreeAppState = {
     variantName: initialVariant,
-    variant: cloneVariant(baseVariant),
+    variant: createVariantState(baseVariant),
     palette: effectivePalette,
     theme,
     parallax,
@@ -233,7 +234,7 @@ export const initScene = async ({
       nextState = {
         ...nextState,
         variantName: partial.variantName,
-        variant: cloneVariant(mapped),
+        variant: createVariantState(mapped),
       };
       changed = true;
       shapes.applyVariant(nextState.variant);
@@ -321,7 +322,7 @@ export const initScene = async ({
     }
 
     if (partial.variant) {
-      nextState = { ...nextState, variant: cloneVariant(partial.variant) };
+      nextState = { ...nextState, variant: createVariantState(partial.variant) };
       shapes.applyVariant(nextState.variant);
       changed = true;
     }


### PR DESCRIPTION
## Summary
- dispose any existing Three.js handle before initialising a new scene to prevent duplicate camera-only scenes
- streamline lighting in the signature shapes helper by keeping only the ambient and key lights
- remove the redundant cloneVariant helper and add tsconfig.tsbuildinfo to the gitignore

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68de90b41c78832fbba139af942f1aeb