### PR TITLE
Ensure disposed Three.js renderer releases WebGL context

### DIFF
--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -344,6 +344,7 @@ export const initScene = async ({
     window.removeEventListener("pointerenter", pointerEnter);
     window.removeEventListener("pointerleave", pointerLeave);
     shapes.dispose();
+    renderer.forceContextLoss();
     renderer.dispose();
     detachFromWindow(handle);
   };


### PR DESCRIPTION
## Summary
- force the Three.js renderer to lose its WebGL context before disposing so old contexts disappear from dev tools

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68de93f99914832f9d1bdda075cd513b