### PR TITLE
Prevent disposed Three.js scene from continuing to render

### DIFF
--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -128,6 +128,7 @@ export const initScene = async ({
   const clock = new Clock();
   let readyDispatched = false;
   let animationId: number | null = null;
+  let disposed = false;
 
   const isMobile = () =>
     typeof window !== "undefined"
@@ -177,6 +178,10 @@ export const initScene = async ({
   };
 
   const tick = () => {
+    if (disposed) {
+      return;
+    }
+
     const delta = clock.getDelta();
     const elapsed = clock.getElapsedTime();
 
@@ -218,7 +223,9 @@ export const initScene = async ({
       dispatchStateChange(eventTarget, state);
     }
 
-    animationId = window.requestAnimationFrame(tick);
+    if (!disposed) {
+      animationId = window.requestAnimationFrame(tick);
+    }
   };
 
   const setState: ThreeAppHandle["setState"] = (updater: StateUpdater) => {
@@ -335,6 +342,12 @@ export const initScene = async ({
   };
 
   const dispose = () => {
+    if (disposed) {
+      return;
+    }
+
+    disposed = true;
+
     if (animationId !== null) {
       window.cancelAnimationFrame(animationId);
       animationId = null;


### PR DESCRIPTION
## Summary
- add a disposed flag in `initScene` to stop the animation loop once the scene has been disposed
- guard the requestAnimationFrame scheduling and dispose handler to avoid running `renderer.render` after cleanup

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68de957bd850832fb892aeb2e30bdf7e