### PR TITLE
Avoid forcing WebGL context loss during Three.js cleanup

### DIFF
--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -376,7 +376,9 @@ export const initScene = async ({
     globalWindow.removeEventListener("pointerenter", pointerEnter);
     globalWindow.removeEventListener("pointerleave", pointerLeave);
     shapes.dispose();
-    renderer.forceContextLoss();
+    // Keep the renderer cleanup quiet for devtools/extensions by avoiding a
+    // forced context loss. `renderer.dispose()` is enough to release GPU
+    // resources without triggering "Context Lost" warnings.
     renderer.dispose();
     detachFromWindow(handle);
   };


### PR DESCRIPTION
## Summary
- rely on `renderer.dispose()` instead of forcing a WebGL context loss when cleaning up the Three.js scene
- document the reason so DevTools and extensions stop reporting context lost warnings

## Testing
- not run (Next.js ESLint prompt prevents non-interactive execution)


------
https://chatgpt.com/codex/tasks/task_e_68de9bf31550832fa4c62cd1f5f3f80f