### PR TITLE
Add shared page animation to secondary pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -24,7 +24,8 @@ export default function AboutPage() {
               as="p"
               underline={false}
               trigger="none"
-              className="block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+              className="page-animate block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+              data-hero-index={0}
             >
               {t("about.kicker")}
             </AnimatedText>
@@ -33,7 +34,8 @@ export default function AboutPage() {
                 as="h1"
                 underline={false}
                 trigger="none"
-                className="block text-5xl font-semibold text-fg sm:text-6xl"
+                className="page-animate block text-5xl font-semibold text-fg sm:text-6xl"
+                data-hero-index={1}
               >
                 {t("about.title")}
               </AnimatedText>
@@ -41,7 +43,8 @@ export default function AboutPage() {
                 as="p"
                 underline={false}
                 trigger="none"
-                className="block text-lg text-fg/70 sm:text-xl"
+                className="page-animate block text-lg text-fg/70 sm:text-xl"
+                data-hero-index={2}
               >
                 {t("about.subtitle")}
               </AnimatedText>
@@ -51,7 +54,8 @@ export default function AboutPage() {
                 as="p"
                 underline={false}
                 trigger="none"
-                className="block lowercase"
+                className="page-animate block lowercase"
+                data-hero-index={3}
               >
                 {t("about.paragraphs.first")}
               </AnimatedText>
@@ -59,7 +63,8 @@ export default function AboutPage() {
                 as="p"
                 underline={false}
                 trigger="none"
-                className="block lowercase"
+                className="page-animate block lowercase"
+                data-hero-index={4}
               >
                 {t("about.paragraphs.second")}
               </AnimatedText>
@@ -67,7 +72,8 @@ export default function AboutPage() {
                 as="p"
                 underline={false}
                 trigger="none"
-                className="block lowercase"
+                className="page-animate block lowercase"
+                data-hero-index={5}
               >
                 <Trans
                   i18nKey="about.paragraphs.third"
@@ -85,7 +91,7 @@ export default function AboutPage() {
                 />
               </AnimatedText>
             </div>
-            <div className="flex flex-wrap gap-3 pt-6">
+            <div className="page-animate flex flex-wrap gap-3 pt-6" data-hero-index={6}>
               <Link
                 href="/Duartois-Resume.pdf"
                 target="_blank"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -26,7 +26,7 @@ export default function ContactPage() {
       <Navbar />
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70">
-          <div className="space-y-4">
+          <div className="page-animate space-y-4" data-hero-index={0}>
             <AnimatedText
               as="h1"
               underline={false}
@@ -46,7 +46,8 @@ export default function ContactPage() {
           </div>
           <form
             onSubmit={handleSubmit}
-            className="w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)]"
+            className="page-animate w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)]"
+            data-hero-index={1}
           >
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">

--- a/app/globals.css
+++ b/app/globals.css
@@ -171,17 +171,33 @@ html, body {
   background: rgb(var(--glow-flamingo) / 0.2);
 }
 
-.hero-animate {
+.hero-animate,
+.page-animate {
   animation: hero-fade 0.9s cubic-bezier(.22,.61,.36,1) both;
 }
-.hero-animate[data-hero-index="1"] {
+.hero-animate[data-hero-index="1"],
+.page-animate[data-hero-index="1"] {
   animation-delay: 0.12s;
 }
-.hero-animate[data-hero-index="2"] {
+.hero-animate[data-hero-index="2"],
+.page-animate[data-hero-index="2"] {
   animation-delay: 0.24s;
 }
-.hero-animate[data-hero-index="3"] {
+.hero-animate[data-hero-index="3"],
+.page-animate[data-hero-index="3"] {
   animation-delay: 0.36s;
+}
+.hero-animate[data-hero-index="4"],
+.page-animate[data-hero-index="4"] {
+  animation-delay: 0.48s;
+}
+.hero-animate[data-hero-index="5"],
+.page-animate[data-hero-index="5"] {
+  animation-delay: 0.6s;
+}
+.hero-animate[data-hero-index="6"],
+.page-animate[data-hero-index="6"] {
+  animation-delay: 0.72s;
 }
 
 @keyframes hero-fade {
@@ -200,7 +216,8 @@ html, body {
   .btn, .btn-secondary, .link, .hero-button {
     transition: none !important;
   }
-  .hero-animate {
+  .hero-animate,
+  .page-animate {
     animation: none !important;
   }
 }

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -62,7 +62,8 @@ export default function WorkPage() {
               as="p"
               underline={false}
               trigger="none"
-              className="block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+              className="page-animate block text-xs font-medium uppercase tracking-[0.42em] text-fg/65"
+              data-hero-index={0}
             >
               {t("work.previewHint")}
             </AnimatedText>
@@ -70,7 +71,8 @@ export default function WorkPage() {
               as="h1"
               underline={false}
               trigger="none"
-              className="mt-4 block text-4xl font-medium text-fg sm:text-5xl"
+              className="page-animate mt-4 block text-4xl font-medium text-fg sm:text-5xl"
+              data-hero-index={1}
             >
               {t("work.title")}
             </AnimatedText>
@@ -78,11 +80,12 @@ export default function WorkPage() {
               as="p"
               underline={false}
               trigger="none"
-              className="mt-6 block max-w-xl text-base leading-relaxed text-fg/80 sm:text-lg"
+              className="page-animate mt-6 block max-w-xl text-base leading-relaxed text-fg/80 sm:text-lg"
+              data-hero-index={2}
             >
               {t("work.subtitle")}
             </AnimatedText>
-            <ul className="mt-10 flex flex-col gap-3">
+            <ul className="page-animate mt-10 flex flex-col gap-3" data-hero-index={3}>
               {projectOrder.map((projectKey) => (
                 <li key={projectKey}>
                   <button


### PR DESCRIPTION
## Summary
- create a reusable `.page-animate` alias for the hero fade motion and extend delay steps
- apply the shared animation to the About page hero text, body copy, and call to action
- animate the primary sections on the Work and Contact pages for consistent page transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9f84d998832fa090e628f54c7874