### PR TITLE
Normalize language switch handling

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -3,15 +3,24 @@
 import { useEffect, useState } from "react";
 import i18n from "@/app/i18n/config";
 
+type SupportedLanguage = "pt" | "en";
+
+const normalizeLanguage = (lng?: string | null): SupportedLanguage => {
+  if (!lng) return "pt";
+  return lng.startsWith("en") ? "en" : "pt";
+};
+
 export default function LanguageSwitcher() {
-  const [lang, setLang] = useState<"pt" | "en">("pt");
+  const [lang, setLang] = useState<SupportedLanguage>(
+    normalizeLanguage(i18n.language)
+  );
   useEffect(() => {
-    setLang((i18n.language as any) || "pt");
-    const onChanged = (l: string) => setLang((l as any) || "pt");
+    const onChanged = (l: string) => setLang(normalizeLanguage(l));
     i18n.on("languageChanged", onChanged);
+    setLang(normalizeLanguage(i18n.language));
     return () => i18n.off("languageChanged", onChanged);
   }, []);
-  const target = lang === "en" ? "pt" : "en";
+  const target: SupportedLanguage = lang === "en" ? "pt" : "en";
 
   return (
     <a


### PR DESCRIPTION
## Summary
- normalize detected language codes in the language switcher to keep the toggle working when i18next provides regional variants
- keep the switch state in sync with the current i18n language on mount

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df16ba358c832f9adcfb9f168fdfc2