### PR TITLE
Fix language switch integration

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import i18n from "@/app/i18n/config";
 
 type SupportedLanguage = "pt" | "en";
@@ -11,6 +12,7 @@ const normalizeLanguage = (lng?: string | null): SupportedLanguage => {
 };
 
 export default function LanguageSwitcher() {
+  const { t } = useTranslation("common");
   const [lang, setLang] = useState<SupportedLanguage>(
     normalizeLanguage(i18n.language)
   );
@@ -26,7 +28,7 @@ export default function LanguageSwitcher() {
     <a
       href="#"
       title={target.toUpperCase()}
-      aria-label={target === "en" ? "Switch to English" : "Mudar para Português"}
+      aria-label={t("languageSwitcher.ariaLabel")}
       onClick={(e) => {
         e.preventDefault();
         i18n.changeLanguage(target);

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -69,7 +69,7 @@ export default function Navbar() {
                   aria-haspopup="dialog"
                   aria-expanded={isOpen}
                   aria-controls="main-navigation-overlay"
-                  aria-label={isOpen ? "Close menu" : "Open menu"}
+                  aria-label={isOpen ? t("navbar.close") : t("navbar.open")}
                   onClick={() => setIsOpen((v) => !v)}
                 >
                   <div style={{ transform: "none" }}>
@@ -80,7 +80,7 @@ export default function Navbar() {
                       height="48"
                       className="icons-style"
                     >
-                      <title>Menu</title>
+                      <title>{t("navbar.menu")}</title>
                       <circle cx="12" cy="12" r="3"></circle>
                       <circle cx="24" cy="12" r="3"></circle>
                       <circle cx="36" cy="12" r="3"></circle>


### PR DESCRIPTION
## Summary
- wire the language switcher aria label to react-i18next so it reflects the active locale
- translate the navbar menu button labels through the existing common namespace

## Testing
- not run (interactive Next.js lint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68df19829058832fb1501e06053337e9