### PR TITLE
Link home hero copy to locale translations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,35 +1,48 @@
 "use client";
 
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import "./i18n/config";
 import { useThreeSceneSetup } from "./helpers/useThreeSceneSetup";
-import { useEffect } from "react";
+import { ReactNode, useEffect } from "react";
 
 
 export default function HomePage() {
-  function applyBackgroundPositionFromClass(el: HTMLElement) {
-  const cls = el.className || "";
-  const rxX = /background-position-x:\s*([+-]?\d*\.?\d+)px/;
-  const rxY = /background-position-y:\s*([+-]?\d*\.?\d+)px/;
+  const applyBackgroundPositionFromClass = (el: HTMLElement) => {
+    const cls = el.className || "";
+    const rxX = /background-position-x:\s*([+-]?\d*\.?\d+)px/;
+    const rxY = /background-position-y:\s*([+-]?\d*\.?\d+)px/;
 
-  const mx = cls.match(rxX);
-  if (mx) {
-    const x = `${parseFloat(mx[1])}px`;
-    el.style.backgroundPositionX = x;
-    // expõe o valor inicial para os @keyframes via CSS var
-    el.style.setProperty("--wave-x", x);
-  }
+    const mx = cls.match(rxX);
+    if (mx) {
+      const x = `${parseFloat(mx[1])}px`;
+      el.style.backgroundPositionX = x;
+      // expõe o valor inicial para os @keyframes via CSS var
+      el.style.setProperty("--wave-x", x);
+    }
 
-  const my = cls.match(rxY);
-  if (my) {
-    const y = `${parseFloat(my[1])}px`;
-    el.style.backgroundPositionY = y;
-    // (se um dia animar Y também, já fica preparado)
-    el.style.setProperty("--wave-y", y);
-  }
-}
+    const my = cls.match(rxY);
+    if (my) {
+      const y = `${parseFloat(my[1])}px`;
+      el.style.backgroundPositionY = y;
+      // (se um dia animar Y também, já fica preparado)
+      el.style.setProperty("--wave-y", y);
+    }
+  };
 
-
+  const NameHighlight = ({
+    children,
+    waveClassName,
+  }: {
+    children: ReactNode;
+    waveClassName: string;
+  }) => (
+    <div className="name">
+      {children}
+      <div className="wave-wrapper">
+        <div className={waveClassName} />
+      </div>
+    </div>
+  );
 
   useEffect(() => {
     // aplica imediatamente em todos que já vieram do SSR
@@ -82,30 +95,31 @@ export default function HomePage() {
             <div className="intro-wrapper">
               <div className="intro-text">
                 <h3 className="intro-id opacity: 1; transform: none; ">
-                  Eai! Sou 
-                  <div className="name">Matheus Duarte
-                    <div className="wave-wrapper">
-                      <div className="wave background-position-x: 54.6645px;">
-                      </div>
-                    </div>
-                  </div>
+                  <Trans
+                    i18nKey="home.hero.titleLine1"
+                    components={{
+                      name: (
+                        <NameHighlight waveClassName="wave background-position-x: 54.6645px;" />
+                      ),
+                    }}
+                  />
                 </h3>
                 <h3 className="intro-id opacity: 1; transform: none;">
-                  Mas você pode me chamar de
-                  <div className="name">
-                    Duartois
-                    <div className="wave-wrapper">
-                      <div className="wave background-position-x: 79.1168px;">
-                      </div>
-                    </div>
-                  </div>
+                  <Trans
+                    i18nKey="home.hero.titleLine2"
+                    components={{
+                      name: (
+                        <NameHighlight waveClassName="wave background-position-x: 79.1168px;" />
+                      ),
+                    }}
+                  />
                 </h3>
                 <div className="intro-roles">
                   <p className="intro-role opacity: 1; transform: none;">
-                    Sou Graphic designer, UX/UI designer
+                    {t("home.hero.role1")}
                   </p>
                   <p className="intro-role opacity: 1; transform: none;">
-                    &amp; e Desenvolvedor Full-Stack
+                    {t("home.hero.role2")}
                   </p>
                 </div>
                 <div className="intro-links">
@@ -114,7 +128,7 @@ export default function HomePage() {
                       <div className="link-wrapper">
                         <div className="link">
                           <a href="/work">
-                            → Meus projetos
+                            {t("home.hero.ctaProjects")}
                           </a>
                         </div>
                         <div className="link-underline transform: translateX(-101%) translateZ(0px);">
@@ -125,7 +139,7 @@ export default function HomePage() {
                       <div className="link-wrapper">
                         <div className="link">
                           <a href="/about">
-                          → Mais sobre mim
+                            {t("home.hero.ctaAbout")}
                           </a>
                         </div>
                         <div className="link-underline">


### PR DESCRIPTION
## Summary
- replace hardcoded hero copy on the home page with i18next translation keys
- add a reusable highlighted name helper so translated content keeps the animated wave styling
- keep existing background position adjustments while preparing strings for pt/en locales

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1ef700e4832f98117b5624cfe57e