### PR TITLE
Synchronize locale preference across server and client

### DIFF
--- a/app/i18n/I18nProvider.tsx
+++ b/app/i18n/I18nProvider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+
+import i18n from "./config";
+
+type SupportedLang = "pt" | "en";
+
+interface I18nProviderProps {
+  lang: SupportedLang;
+  children: ReactNode;
+}
+
+export default function I18nProvider({ lang, children }: I18nProviderProps) {
+  if (typeof window === "undefined" && i18n.language !== lang) {
+    i18n.changeLanguage(lang);
+  }
+
+  useEffect(() => {
+    if (i18n.language !== lang) {
+      void i18n.changeLanguage(lang);
+    }
+  }, [lang]);
+
+  return <>{children}</>;
+}

--- a/app/i18n/config.ts
+++ b/app/i18n/config.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
@@ -13,9 +11,28 @@ const resources = {
 } as const;
 
 function getInitialLng(): "pt" | "en" {
-  if (typeof window === "undefined") return "pt";
-  const saved = localStorage.getItem("i18nextLng");
-  return saved === "en" ? "en" : "pt";
+  if (typeof document !== "undefined") {
+    const attr = document.documentElement.getAttribute("lang");
+    if (attr === "pt" || attr === "en") {
+      return attr;
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    const saved = window.localStorage.getItem("i18nextLng");
+    if (saved === "en" || saved === "pt") {
+      return saved;
+    }
+  }
+
+  if (typeof navigator !== "undefined") {
+    const preferred = navigator.language?.slice(0, 2);
+    if (preferred === "en" || preferred === "pt") {
+      return preferred;
+    }
+  }
+
+  return "pt";
 }
 
 if (!i18n.isInitialized) {
@@ -37,8 +54,18 @@ if (!i18n.isInitialized) {
 }
 
 i18n.on("languageChanged", (lng) => {
-  try { localStorage.setItem("i18nextLng", lng); } catch {}
-  if (typeof document !== "undefined") document.documentElement.setAttribute("lang", lng);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem("i18nextLng", lng);
+    } catch {}
+  }
+
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("lang", lng);
+    try {
+      document.cookie = `i18nextLng=${lng}; path=/; max-age=31536000`;
+    } catch {}
+  }
 });
 
 export default i18n;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,27 @@
 import "./globals.css";
 import type { ReactNode } from "react";
 import classNames from "classnames";
+import { cookies } from "next/headers";
 import AppShell from "@/components/AppShell";
 import ThemeScript from "./theme/ThemeScript";
 import { ThemeProvider } from "./theme/ThemeContext";
 import Navbar from "@/components/Navbar";
+import I18nProvider from "./i18n/I18nProvider";
+
+type SupportedLang = "pt" | "en";
+
+function resolveLanguage(): SupportedLang {
+  const cookieStore = cookies();
+  const cookieLang = cookieStore.get("i18nextLng")?.value;
+  return cookieLang === "en" ? "en" : "pt";
+}
 
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const lang = resolveLanguage();
+
   return (
-    <html lang="pt" suppressHydrationWarning>
+    <html lang={lang} suppressHydrationWarning>
       <head>
         <ThemeScript />
       </head>
@@ -19,8 +31,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         )}
       >
         <ThemeProvider>
-          <Navbar />
-          <AppShell>{children}</AppShell>
+          <I18nProvider lang={lang}>
+            <Navbar />
+            <AppShell>{children}</AppShell>
+          </I18nProvider>
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- read the persisted language from cookies in the root layout and expose it to the app
- add an I18nProvider that aligns the i18next instance with the server-selected language on both server and client
- persist locale changes in a cookie and derive the initial language from the document to avoid hydration mismatches

## Testing
- not run (requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68df27e20b98832f9a19f25ddb7f425f