### PR TITLE
Ensure noise overlay renders above Three.js canvas

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -3,7 +3,6 @@
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
 import CanvasRoot from "./three/CanvasRoot";
-import Noise from "./Noise";
 
 interface AppShellProps {
   children: ReactNode;
@@ -36,7 +35,6 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="relative min-h-screen w-full overflow-hidden">
-      <Noise />
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
       {canRenderContent ? (

--- a/components/Noise.jsx
+++ b/components/Noise.jsx
@@ -1,10 +1,12 @@
+import classNames from "classnames";
+
 import noise from "@/public/noise.png";
 
-export default function Noise() {
+export default function Noise({ className = "" }) {
   return (
     <div
       aria-hidden
-      className="pointer-events-none fixed inset-0 z-30"
+      className={classNames("pointer-events-none fixed inset-0 z-30", className)}
       style={{
         backgroundImage: `url(${noise.src})`,
         backgroundRepeat: "repeat",

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -36,20 +36,26 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
   }
 
   return (
-    <div className="fixed w-full h-full top-0 left-0 z-0">
-    <div
-      className={classNames(
-        "pointer-events-none fixed inset-0 z-0 overflow-visible transition-opacity duration-700",
-        isVisible ? "opacity-100" : "opacity-0",
-      )}
-      aria-hidden={!isVisible}
-    >
-      <div className="relative h-full w-full">
-        <div className="absolute inset-0 z-0">
-          <CoreCanvas />
+    <div className="fixed top-0 left-0 h-full w-full z-0">
+      <div
+        className={classNames(
+          "pointer-events-none fixed inset-0 z-0 overflow-visible transition-opacity duration-700",
+          isVisible ? "opacity-100" : "opacity-0",
+        )}
+        aria-hidden={!isVisible}
+      >
+        <div className="relative h-full w-full">
+          <div className="absolute inset-0 z-0">
+            <CoreCanvas />
+          </div>
         </div>
       </div>
-    </div>
+      <Noise
+        className={classNames(
+          "z-30 transition-opacity duration-700",
+          isVisible ? "opacity-100" : "opacity-0",
+        )}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep the Noise overlay within CanvasRoot but render it after the canvas container so it stays layered above the 3D scene
- allow passing additional class names to the Noise component so the overlay can share CanvasRoot transitions

## Testing
- type-check (fails: Cannot find module '../../components/AnimatedText' from app/contact/page.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68df29bc83fc832f916720686d07a6ea