### PR TITLE
Move noise overlay to app shell

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
+import Noise from "./Noise";
 import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
@@ -35,6 +36,7 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="relative min-h-screen w-full overflow-hidden">
+      <Noise className="z-[60]" />
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
       {canRenderContent ? (

--- a/components/Noise.tsx
+++ b/components/Noise.tsx
@@ -1,10 +1,14 @@
 import noise from "@/public/noise.png";
 
 export default function Noise({ className = "" }) {
+  const classes = ["pointer-events-none fixed inset-0 z-30", className]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <div
       aria-hidden
-      className="pointer-events-none fixed inset-0 z-30"
+      className={classes}
       style={{
         backgroundImage: `url(${noise.src})`,
         backgroundRepeat: "repeat",

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -2,8 +2,6 @@
 
 import classNames from "classnames";
 import { useEffect, useState } from "react";
-import Noise from "../Noise";
-
 import CoreCanvas from "./CoreCanvas";
 
 interface CanvasRootProps {
@@ -50,12 +48,6 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
           </div>
         </div>
       </div>
-      <Noise
-        className={classNames(
-          "z-30 transition-opacity duration-700",
-          isVisible ? "opacity-100" : "opacity-0",
-        )}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move the noise overlay into the app shell so it covers the preloader and 3D canvas
- allow the Noise component to accept extra classes for configurable z-index

## Testing
- not run (requires eslint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68df2ee62880832f9a3b8d5ef65f5f8b