### PR TITLE
Allow Noise component z-index override

### DIFF
--- a/components/Noise.tsx
+++ b/components/Noise.tsx
@@ -1,7 +1,12 @@
 import noise from "@/public/noise.png";
 
-export default function Noise({ className = "" }) {
-  const classes = ["pointer-events-none fixed inset-0 z-30", className]
+type NoiseProps = {
+  className?: string;
+};
+
+export default function Noise({ className }: NoiseProps) {
+  const baseClasses = "pointer-events-none fixed inset-0";
+  const classes = [baseClasses, className ?? "z-[60]"]
     .filter(Boolean)
     .join(" ");
 


### PR DESCRIPTION
## Summary
- allow the Noise overlay to keep base positioning while defaulting to a high z-index when none is provided
- confirm AppShell continues supplying the high z-index to keep the noise layer above the background and 3D elements

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68df32a1e550832fb8282022940e4ef3