### PR TITLE
Update Noise component to use static noise background

### DIFF
--- a/components/Noise.tsx
+++ b/components/Noise.tsx
@@ -1,5 +1,3 @@
-import noise from "@/public/noise.png";
-
 type NoiseProps = {
   className?: string;
 };
@@ -15,7 +13,7 @@ export default function Noise({ className }: NoiseProps) {
       aria-hidden
       className={classes}
       style={{
-        backgroundImage: `url(${noise.src})`,
+        backgroundImage: 'url("/noise.png")',
         backgroundRepeat: "repeat",
         mixBlendMode: "soft-light",
         opacity: 0.12,


### PR DESCRIPTION
## Summary
- remove the noise image import from the Noise component
- reference the public noise asset directly in the inline background style

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df34f5677c832f80caff519540bd24