### PR TITLE
Overlay noise above three.js canvas

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,7 +2,6 @@
 
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
-import Noise from "./Noise";
 import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
@@ -36,7 +35,6 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="relative min-h-screen w-full overflow-hidden">
-      <Noise className="z-[60]" />
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
       {canRenderContent ? (

--- a/components/Noise.tsx
+++ b/components/Noise.tsx
@@ -1,9 +1,10 @@
 type NoiseProps = {
   className?: string;
+  position?: "fixed" | "absolute";
 };
 
-export default function Noise({ className }: NoiseProps) {
-  const baseClasses = "pointer-events-none fixed inset-0";
+export default function Noise({ className, position = "fixed" }: NoiseProps) {
+  const baseClasses = `pointer-events-none ${position} inset-0`;
   const classes = [baseClasses, className ?? "z-[60]"]
     .filter(Boolean)
     .join(" ");

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -2,6 +2,7 @@
 
 import classNames from "classnames";
 import { useEffect, useState } from "react";
+import Noise from "../Noise";
 import CoreCanvas from "./CoreCanvas";
 
 interface CanvasRootProps {
@@ -34,19 +35,18 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
   }
 
   return (
-    <div className="fixed top-0 left-0 h-full w-full z-0">
-      <div
-        className={classNames(
-          "pointer-events-none fixed inset-0 -z-10 overflow-visible transition-opacity duration-700",
-          isVisible ? "opacity-100" : "opacity-0",
-        )}
-        aria-hidden={!isVisible}
-      >
-        <div className="relative h-full w-full">
-          <div className="absolute inset-0 z-10">
-            <CoreCanvas />
-          </div>
+    <div
+      className={classNames(
+        "pointer-events-none fixed inset-0 z-0 overflow-visible transition-opacity duration-700",
+        isVisible ? "opacity-100" : "opacity-0",
+      )}
+      aria-hidden={!isVisible}
+    >
+      <div className="relative h-full w-full">
+        <div className="absolute inset-0 z-0">
+          <CoreCanvas />
         </div>
+        <Noise position="absolute" className="z-[10]" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move the noise overlay management into the Three.js canvas root so it layers above the scene
- allow the noise overlay component to switch between fixed and absolute positioning for reuse within the canvas stack
- simplify the app shell by removing the direct noise import now that the canvas handles it

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68df3819f5e8832f9c37454d429c0bf0