### PR TITLE
Place noise overlay above preloader and three canvas

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import Preloader from "./Preloader";
+import Noise from "./Noise";
 import CanvasRoot from "./three/CanvasRoot";
 
 interface AppShellProps {
@@ -37,6 +38,7 @@ export default function AppShell({ children }: AppShellProps) {
     <div className="relative min-h-screen w-full overflow-hidden">
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
+      <Noise className="z-[70]" />
       {canRenderContent ? (
         <div
           className={`${

--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -2,7 +2,6 @@
 
 import classNames from "classnames";
 import { useEffect, useState } from "react";
-import Noise from "../Noise";
 import CoreCanvas from "./CoreCanvas";
 
 interface CanvasRootProps {
@@ -46,7 +45,6 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
         <div className="absolute inset-0 z-0">
           <CoreCanvas />
         </div>
-        <Noise position="absolute" className="z-[10]" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move the noise overlay to the app shell so it renders above other fixed layers
- ensure the three.js canvas no longer duplicates the noise overlay

## Testing
- not run (lint requires interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_68df3f4aad6c832f9f7ffdbd854de461