### PR TITLE
Clone hover variants before applying

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,6 +52,13 @@ function NameWithWave({
       alignment === "centered" && centeredHoverVariant
         ? centeredHoverVariant
         : hoverVariant;
+    const clonedVariant = createVariantState(nextVariant);
+    const clonedHoverVariants = centeredHoverVariant
+      ? {
+          desktop: createVariantState(hoverVariant),
+          centered: createVariantState(centeredHoverVariant),
+        }
+      : null;
 
     app.setState((previous) => {
       if (!storedVariantRef.current) {
@@ -59,14 +66,9 @@ function NameWithWave({
       }
       return {
         hovered: true,
-        variant: nextVariant,
+        variant: clonedVariant,
         hoverAlignment: alignment,
-        hoverVariants: centeredHoverVariant
-          ? {
-              desktop: hoverVariant,
-              centered: centeredHoverVariant,
-            }
-          : null,
+        hoverVariants: clonedHoverVariants,
       };
     });
   }, [centeredHoverVariant, hoverVariant]);


### PR DESCRIPTION
## Summary
- clone hover variants before updating the three.js scene so constants are not mutated
- ensure stored hover variant sets are also cloned to keep transitions anchored to the framed state

## Testing
- npm run lint *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e05322a938832f98b2f3b4a78c906b