### PR TITLE
Prevent hover exit from replaying initial 3D reveal

### DIFF
--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -43,7 +43,7 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
     >
       <div className="relative h-full w-full">
         <div className="absolute inset-0 z-0">
-          <CoreCanvas />
+          <CoreCanvas isReady={isReady} />
         </div>
       </div>
     </div>

--- a/components/three/CoreCanvas.tsx
+++ b/components/three/CoreCanvas.tsx
@@ -6,7 +6,11 @@ import { useTheme } from "@/app/theme/ThemeContext";
 import { initScene } from "./initScene";
 import type { ThreeAppHandle } from "./types";
 
-export default function CoreCanvas() {
+interface CoreCanvasProps {
+  isReady: boolean;
+}
+
+export default function CoreCanvas({ isReady }: CoreCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const handleRef = useRef<ThreeAppHandle | null>(null);
   const { theme } = useTheme();
@@ -40,6 +44,14 @@ export default function CoreCanvas() {
     if (!handleRef.current) return;
     handleRef.current.setState({ theme });
   }, [theme]);
+
+  useEffect(() => {
+    if (!handleRef.current) {
+      return;
+    }
+
+    handleRef.current.setState({ primordialRevealComplete: isReady });
+  }, [isReady]);
 
   return (
     <canvas

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -237,6 +237,7 @@ export const initScene = async ({
     manualPointer: { x: 0, y: 0 },
     opacity: 1,
     brightness: DEFAULT_BRIGHTNESS,
+    primordialRevealComplete: false,
     ready: false,
   };
 
@@ -427,6 +428,17 @@ export const initScene = async ({
       commit({ theme: partial.theme, palette: nextPalette });
     }
 
+    if (
+      Object.prototype.hasOwnProperty.call(partial, "primordialRevealComplete")
+    ) {
+      const nextPrimordial =
+        (partial as { primordialRevealComplete?: boolean })
+          .primordialRevealComplete ?? false;
+      if (nextPrimordial !== state.primordialRevealComplete) {
+        commit({ primordialRevealComplete: nextPrimordial });
+      }
+    }
+
     if (typeof partial.brightness === "number") {
       const nextBrightness = clamp(partial.brightness, 0.5, 2);
       if (nextBrightness !== state.brightness) {
@@ -439,8 +451,15 @@ export const initScene = async ({
       commit({ parallax: partial.parallax });
     }
 
-    if (typeof partial.hovered === "boolean" && partial.hovered !== state.hovered) {
-      commit({ hovered: partial.hovered });
+    const hoveredProvided = Object.prototype.hasOwnProperty.call(
+      partial,
+      "hovered",
+    );
+    if (hoveredProvided) {
+      const nextHovered = (partial as { hovered?: boolean }).hovered ?? false;
+      if (nextHovered !== state.hovered) {
+        commit({ hovered: nextHovered });
+      }
     }
 
     if (Object.prototype.hasOwnProperty.call(partial, "hoverAlignment")) {
@@ -502,10 +521,19 @@ export const initScene = async ({
       }
     }
 
+    const shouldSnapVariant =
+      state.hovered &&
+      hoveredProvided &&
+      (partial as { hovered?: boolean }).hovered === false &&
+      state.primordialRevealComplete;
+
     if (partial.variant) {
       const nextVariant = createVariantState(partial.variant);
       targetVariantState = nextVariant;
       updateVariantBounds(nextVariant);
+      if (shouldSnapVariant) {
+        shapes.applyVariant(nextVariant);
+      }
       commit({ variant: createVariantState(partial.variant) });
     }
 

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -304,6 +304,7 @@ export type ThreeAppState = {
   manualPointer: PointerTarget;
   opacity: number;
   brightness: number;
+  primordialRevealComplete: boolean;
   ready: boolean;
 };
 


### PR DESCRIPTION
## Summary
- add a primordial reveal completion flag to the three.js app state so the base layout animation only plays after the preload
- propagate the preload readiness flag into the core canvas and snap back to the framed variant without interpolation when leaving a hover once the preload has finished
- wire CanvasRoot/CoreCanvas to pass the readiness state through to the three app handle

## Testing
- attempted `npm run lint` *(fails: interactive prompt asking for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e05600266c832f8ece507a2a1c6a58