### PR TITLE
Adjust monogram variants for responsive viewport behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,8 @@ import {
   HERO_LINE_ONE_MONOGRAM,
   HERO_LINE_TWO_MONOGRAM,
   createVariantState,
+  createResponsiveHeroVariantState,
+  createResponsiveVariantState,
   variantMapping,
   type VariantState,
 } from "@/components/three/types";
@@ -36,13 +38,19 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
       return;
     }
 
+    const responsiveHover = createResponsiveHeroVariantState(
+      hoverVariant,
+      window.innerWidth,
+      window.innerHeight,
+    );
+
     app.setState((previous) => {
       if (!storedVariantRef.current) {
         storedVariantRef.current = createVariantState(previous.variant);
       }
       return {
         hovered: true,
-        variant: hoverVariant,
+        variant: responsiveHover,
       };
     });
   }, [hoverVariant]);
@@ -63,7 +71,11 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
       app.setState((previous) => {
         const fallback =
           storedVariantRef.current ??
-          createVariantState(variantMapping[previous.variantName]);
+          createResponsiveVariantState(
+            variantMapping[previous.variantName],
+            window.innerWidth,
+            window.innerHeight,
+          );
 
         storedVariantRef.current = null;
 

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -16,6 +16,7 @@ import {
   type ThemeName,
   type VariantName,
   createVariantState,
+  createResponsiveVariantState,
   getDefaultPalette,
   variantMapping,
 } from "./types";
@@ -99,7 +100,11 @@ export const initScene = async ({
 
   const effectivePalette = ensurePalette(palette, theme);
   const baseVariantTemplate = variantMapping[initialVariant];
-  const initialVariantState = createVariantState(baseVariantTemplate);
+  const initialVariantState = createResponsiveVariantState(
+    baseVariantTemplate,
+    globalWindow.innerWidth,
+    globalWindow.innerHeight,
+  );
   const shapes = await addDuartoisSignatureShapes(
     scene,
     initialVariantState,
@@ -194,6 +199,14 @@ export const initScene = async ({
     ortho.top = 1;
     ortho.bottom = -1;
     ortho.updateProjectionMatrix();
+
+    setState((previous) => ({
+      variant: createResponsiveVariantState(
+        variantMapping[previous.variantName],
+        width,
+        height,
+      ),
+    }));
   };
 
 
@@ -319,8 +332,16 @@ export const initScene = async ({
 
     if (partial.variantName && partial.variantName !== state.variantName) {
       const mapped = variantMapping[partial.variantName];
-      targetVariantState = createVariantState(mapped);
-      commit({ variantName: partial.variantName, variant: createVariantState(mapped) });
+      const responsiveVariant = createResponsiveVariantState(
+        mapped,
+        globalWindow.innerWidth,
+        globalWindow.innerHeight,
+      );
+      targetVariantState = createVariantState(responsiveVariant);
+      commit({
+        variantName: partial.variantName,
+        variant: createVariantState(responsiveVariant),
+      });
     }
 
     if (partial.palette) {

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -140,6 +140,104 @@ export const variantMapping: Record<VariantName, VariantState> = {
   contact: createFramedVariant(),
 };
 
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const BASE_VIEWPORT_WIDTH = 1440;
+const BASE_VIEWPORT_HEIGHT = 900;
+const MIN_VIEWPORT_SCALE = 0.55;
+
+const SHAPE_IDS: readonly ShapeId[] = [
+  "torusSpringAzure",
+  "waveSpringLime",
+  "semiLimeFlamingo",
+  "torusFlamingoLime",
+  "semiFlamingoAzure",
+  "sphereFlamingoSpring",
+];
+
+export const createResponsiveVariantState = (
+  variant: VariantState,
+  viewportWidth: number,
+  viewportHeight: number,
+): VariantState => {
+  const widthScale = viewportWidth / BASE_VIEWPORT_WIDTH;
+  const heightScale = viewportHeight / BASE_VIEWPORT_HEIGHT;
+  const uniformScale = clamp(Math.min(widthScale, heightScale), MIN_VIEWPORT_SCALE, 1);
+
+  const responsiveState = {} as VariantState;
+
+  SHAPE_IDS.forEach((shapeId) => {
+    const source = variant[shapeId];
+    const [px, py, pz] = source.position;
+    const [rx, ry, rz] = source.rotation;
+    const scaledScale = Array.isArray(source.scale)
+      ? ([
+          source.scale[0] * uniformScale,
+          source.scale[1] * uniformScale,
+          source.scale[2] * uniformScale,
+        ] as Vector3Tuple)
+      : source.scale * uniformScale;
+
+    responsiveState[shapeId] = {
+      position: [
+        px * uniformScale,
+        py * uniformScale,
+        pz * uniformScale,
+      ] as Vector3Tuple,
+      rotation: [rx, ry, rz] as Vector3Tuple,
+      scale: scaledScale,
+    };
+  });
+
+  return responsiveState;
+};
+
+export const createResponsiveHeroVariantState = (
+  variant: VariantState,
+  viewportWidth: number,
+  viewportHeight: number,
+  centerBelowWidth = 990,
+): VariantState => {
+  const responsiveVariant = createResponsiveVariantState(
+    variant,
+    viewportWidth,
+    viewportHeight,
+  );
+
+  if (viewportWidth > centerBelowWidth) {
+    return responsiveVariant;
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  SHAPE_IDS.forEach((shapeId) => {
+    const [x, y] = responsiveVariant[shapeId].position;
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+  });
+
+  if (!Number.isFinite(minX) || !Number.isFinite(maxX)) {
+    return responsiveVariant;
+  }
+
+  const offsetX = -((minX + maxX) / 2);
+  const offsetY = -((minY + maxY) / 2);
+
+  SHAPE_IDS.forEach((shapeId) => {
+    const transform = responsiveVariant[shapeId];
+    const [x, y, z] = transform.position;
+    transform.position = [x + offsetX, y + offsetY, z] as Vector3Tuple;
+  });
+
+  return responsiveVariant;
+};
+
 export const LIGHT_THEME_PALETTE: GradientPalette = [
   ["#ffb3c2", "#ffc3cf", "#ffd4dc", "#ffe4ea"],
   ["#99b9ff", "#aec7ff", "#c3d6ff", "#d8e4ff"],


### PR DESCRIPTION
## Summary
- add responsive variant helpers that scale and center three.js shape layouts based on viewport dimensions
- update initial scene setup and resize handling to apply responsive variants across the app
- adapt hero hover interactions to use responsive variants and center monograms on narrow screens

## Testing
- `npm run lint` *(fails: requires interactive eslint setup, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e064234a7c832f865688e91daaa7e8