### PR TITLE
Adjust monogram variants for responsive viewport behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,8 @@ import {
   HERO_LINE_ONE_MONOGRAM,
   HERO_LINE_TWO_MONOGRAM,
   createVariantState,
+  createResponsiveHeroVariantState,
+  createResponsiveVariantState,
   variantMapping,
   type VariantState,
 } from "@/components/three/types";
@@ -36,13 +38,19 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
       return;
     }
 
+    const responsiveHover = createResponsiveHeroVariantState(
+      hoverVariant,
+      window.innerWidth,
+      window.innerHeight,
+    );
+
     app.setState((previous) => {
       if (!storedVariantRef.current) {
         storedVariantRef.current = createVariantState(previous.variant);
       }
       return {
         hovered: true,
-        variant: hoverVariant,
+        variant: responsiveHover,
       };
     });
   }, [hoverVariant]);
@@ -63,7 +71,11 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
       app.setState((previous) => {
         const fallback =
           storedVariantRef.current ??
-          createVariantState(variantMapping[previous.variantName]);
+          createResponsiveVariantState(
+            variantMapping[previous.variantName],
+            window.innerWidth,
+            window.innerHeight,
+          );
 
         storedVariantRef.current = null;
 

--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -16,6 +16,7 @@ import {
   type ThemeName,
   type VariantName,
   createVariantState,
+  createResponsiveVariantState,
   getDefaultPalette,
   variantMapping,
 } from "./types";
@@ -99,7 +100,11 @@ export const initScene = async ({
 
   const effectivePalette = ensurePalette(palette, theme);
   const baseVariantTemplate = variantMapping[initialVariant];
-  const initialVariantState = createVariantState(baseVariantTemplate);
+  const initialVariantState = createResponsiveVariantState(
+    baseVariantTemplate,
+    globalWindow.innerWidth,
+    globalWindow.innerHeight,
+  );
   const shapes = await addDuartoisSignatureShapes(
     scene,
     initialVariantState,
@@ -194,6 +199,14 @@ export const initScene = async ({
     ortho.top = 1;
     ortho.bottom = -1;
     ortho.updateProjectionMatrix();
+
+    setState((previous) => ({
+      variant: createResponsiveVariantState(
+        variantMapping[previous.variantName],
+        width,
+        height,
+      ),
+    }));
   };
 
 
@@ -319,8 +332,16 @@ export const initScene = async ({
 
     if (partial.variantName && partial.variantName !== state.variantName) {
       const mapped = variantMapping[partial.variantName];
-      targetVariantState = createVariantState(mapped);
-      commit({ variantName: partial.variantName, variant: createVariantState(mapped) });
+      const responsiveVariant = createResponsiveVariantState(
+        mapped,
+        globalWindow.innerWidth,
+        globalWindow.innerHeight,
+      );
+      targetVariantState = createVariantState(responsiveVariant);
+      commit({
+        variantName: partial.variantName,
+        variant: createVariantState(responsiveVariant),
+      });
     }
 
     if (partial.palette) {


### PR DESCRIPTION
## Summary
- add responsive variant helpers that scale and center three.js shape layouts based on viewport dimensions
- update initial scene setup and resize handling to apply responsive variants across the app
- adapt hero hover interactions to use responsive variants and center monograms on narrow screens
- extend hero responsive variants to partially center monograms between 990px and 1700px wide viewports

## Testing
- `npm run lint` *(fails: requires interactive eslint setup, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e064234a7c832f865688e91daaa7e8