### PR TITLE
Adjust hero hover offsets for tablet widths

### DIFF
--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -198,6 +198,7 @@ export const createResponsiveHeroVariantState = (
   viewportWidth: number,
   viewportHeight: number,
   centerBelowWidth = 990,
+  partiallyCenterBelowWidth = 1700,
 ): VariantState => {
   const responsiveVariant = createResponsiveVariantState(
     variant,
@@ -205,7 +206,7 @@ export const createResponsiveHeroVariantState = (
     viewportHeight,
   );
 
-  if (viewportWidth > centerBelowWidth) {
+  if (viewportWidth > partiallyCenterBelowWidth) {
     return responsiveVariant;
   }
 
@@ -229,10 +230,18 @@ export const createResponsiveHeroVariantState = (
   const offsetX = -((minX + maxX) / 2);
   const offsetY = -((minY + maxY) / 2);
 
+  const applyFullCenter = viewportWidth <= centerBelowWidth;
+  const horizontalFactor = applyFullCenter ? 1 : 0.5;
+  const verticalFactor = applyFullCenter ? 1 : 0;
+
   SHAPE_IDS.forEach((shapeId) => {
     const transform = responsiveVariant[shapeId];
     const [x, y, z] = transform.position;
-    transform.position = [x + offsetX, y + offsetY, z] as Vector3Tuple;
+    transform.position = [
+      x + offsetX * horizontalFactor,
+      y + offsetY * verticalFactor,
+      z,
+    ] as Vector3Tuple;
   });
 
   return responsiveVariant;


### PR DESCRIPTION
## Summary
- partially center the hero hover variant when the viewport width is between 990px and 1700px to keep the 3D elements inside the frame
- retain full centering on small screens and the existing layout on very wide viewports

## Testing
- not run (requires interactive Next.js ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68e06ac8b35c832f98b9095cb9287005