### PR TITLE
Add hover variants to Three app state

### DIFF
--- a/components/three/initScene.ts
+++ b/components/three/initScene.ts
@@ -145,6 +145,7 @@ export const initScene = async ({
   const initialState: ThreeAppState = {
     variantName: initialVariant,
     variant: createVariantState(initialVariantClone),
+    hoverVariants: null,
     palette: effectivePalette,
     theme,
     parallax,

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -270,6 +270,10 @@ export const DEFAULT_BRIGHTNESS = 1.2;
 export type ThreeAppState = {
   variantName: VariantName;
   variant: VariantState;
+  hoverVariants: {
+    desktop: VariantState;
+    centered: VariantState;
+  } | null;
   palette: GradientPalette;
   theme: ThemeName;
   parallax: boolean;


### PR DESCRIPTION
## Summary
- extend `ThreeAppState` with an optional `hoverVariants` snapshot
- initialize the property in the Three scene setup to keep type checks happy

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e0739a7844832f8cc9d4ab63773c9f