### PR TITLE
Fix merged geometry attribute assignment for Safari

### DIFF
--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -83,6 +83,12 @@ const mergeGeometries = (
       offset += array.length;
     }
 
+    const attribute = new THREE.BufferAttribute(
+      mergedArray,
+      info.itemSize,
+      info.normalized,
+    );
+    mergedGeometry.setAttribute(name, attribute);
   });
 
   if (useGroups) {


### PR DESCRIPTION
## Summary
- ensure merged tube geometries retain their buffer attributes when combining shapes so all forms render

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0757d3760832f9246a4b33e24e7aa