### PR TITLE
Add custom cursor overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,47 +39,38 @@ main {
 }
 .cursor,.cursor-dot {
     position: fixed;
+    top: 0;
+    left: 0;
     pointer-events: none;
-    top: 50%;
-    left: 50%;
-    border-radius: 50%;
+    border-radius: 9999px;
+    transform: translate3d(-50%,-50%,0);
+    opacity: 0;
+    transition: opacity .2s ease,transform .18s ease;
     z-index: 999;
-    transform: translate(-50%,-50%);
-    -webkit-animation: .1s;
-    animation: .1s;
-    overflow: hidden
+    mix-blend-mode: multiply
 }
 
 .cursor {
-    width: 24px;
-    height: 24px;
-    background-color: #606887;
-    border-color: #606887;
-    mix-blend-mode: multiply
-}
-
-.cursor body.dark {
-    background-color: #f3f2f9;
-    border-color: #f3f2f9;
-    mix-blend-mode: difference
+    width: 32px;
+    height: 32px;
+    border: 1px solid rgba(96,104,135,.4);
+    background-color: rgba(96,104,135,.1)
 }
 
 .cursor-dot {
-    width: 4px;
-    height: 4px;
-    background-color: #606887;
-    -webkit-animation: .4s linear;
-    animation: .4s linear;
-    mix-blend-mode: multiply
+    width: 6px;
+    height: 6px;
+    background-color: #606887
 }
 
-.cursor-dot .body.dark,body.dark .cursor {
-    background-color: #f3f2f9;
-    mix-blend-mode: difference
+body.cursor-enabled,body.cursor-enabled * {
+    cursor: none !important
 }
 
 body.dark .cursor {
-    border-color: #f3f2f9
+    border-color: rgba(243,242,249,.7);
+    background-color: rgba(243,242,249,.08);
+    mix-blend-mode: difference
 }
 
 body.dark .cursor-dot {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import AppShell from "@/components/AppShell";
 import ThemeScript from "./theme/ThemeScript";
 import { ThemeProvider } from "./theme/ThemeContext";
 import Navbar from "@/components/Navbar";
+import CustomCursor from "@/components/CustomCursor";
 import I18nProvider from "./i18n/I18nProvider";
 
 type SupportedLang = "pt" | "en";
@@ -32,6 +33,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       >
         <ThemeProvider>
           <I18nProvider lang={lang}>
+            <CustomCursor />
             <Navbar />
             <AppShell>{children}</AppShell>
           </I18nProvider>

--- a/components/CustomCursor.tsx
+++ b/components/CustomCursor.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+function applyTransform(
+  element: HTMLDivElement,
+  x: number,
+  y: number,
+  scale = 1,
+) {
+  element.style.transform = `translate3d(${x}px, ${y}px, 0) translate(-50%, -50%) scale(${scale})`;
+}
+
+export default function CustomCursor() {
+  const dotRef = useRef<HTMLDivElement>(null);
+  const cursorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const dot = dotRef.current;
+    const cursor = cursorRef.current;
+
+    if (!dot || !cursor) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(pointer: fine)");
+
+    if (!mediaQuery.matches) {
+      return;
+    }
+
+    document.body.classList.add("cursor-enabled");
+
+    let raf = 0;
+    let latestX = 0;
+    let latestY = 0;
+
+    const show = () => {
+      dot.style.opacity = "1";
+      cursor.style.opacity = "1";
+    };
+
+    const hide = () => {
+      dot.style.opacity = "0";
+      cursor.style.opacity = "0";
+    };
+
+    const update = (scale = 1) => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        applyTransform(dot, latestX, latestY);
+        applyTransform(cursor, latestX, latestY, scale);
+      });
+    };
+
+    const handleMove = (event: MouseEvent) => {
+      latestX = event.clientX;
+      latestY = event.clientY;
+      show();
+      update();
+    };
+
+    const handleDown = () => {
+      update(0.85);
+    };
+
+    const handleUp = () => {
+      update();
+    };
+
+    const handleLeave = () => {
+      hide();
+    };
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("mousedown", handleDown);
+    window.addEventListener("mouseup", handleUp);
+    window.addEventListener("mouseenter", show);
+    window.addEventListener("mouseleave", handleLeave);
+
+    return () => {
+      document.body.classList.remove("cursor-enabled");
+      cancelAnimationFrame(raf);
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("mousedown", handleDown);
+      window.removeEventListener("mouseup", handleUp);
+      window.removeEventListener("mouseenter", show);
+      window.removeEventListener("mouseleave", handleLeave);
+      hide();
+    };
+  }, []);
+
+  return (
+    <>
+      <div ref={dotRef} className="cursor-dot" />
+      <div ref={cursorRef} className="cursor" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side CustomCursor component that tracks pointer movement and renders the cursor elements
- style the cursor dot and ring globally and hide the native cursor on pointer devices
- mount the custom cursor in the root layout so it appears across the entire app

## Testing
- not run (npm run lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e0bd2eceb0832fbd1c0da6937fe25d