### PR TITLE
Enhance custom cursor animation and hover effects

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,7 +37,8 @@ main {
     overflow: hidden;
     width: 100%
 }
-.cursor,.cursor-dot {
+.cursor,
+.cursor-dot {
     position: fixed;
     top: 0;
     left: 0;
@@ -45,7 +46,7 @@ main {
     border-radius: 9999px;
     transform: translate3d(-50%,-50%,0);
     opacity: 0;
-    transition: opacity .2s ease,transform .18s ease;
+    transition: opacity .2s ease;
     z-index: 999;
     mix-blend-mode: multiply
 }
@@ -54,13 +55,26 @@ main {
     width: 32px;
     height: 32px;
     border: 1px solid rgba(96,104,135,.4);
-    background-color: rgba(96,104,135,.1)
+    background-color: rgba(96,104,135,.1);
+    transition: opacity .2s ease,background-color .2s ease,border-color .2s ease;
+    will-change: transform
 }
 
 .cursor-dot {
     width: 6px;
     height: 6px;
-    background-color: #606887
+    background-color: #606887;
+    transition: opacity .2s ease;
+    will-change: transform
+}
+
+.cursor--link {
+    background-color: rgb(96,104,135);
+    border-color: rgb(96,104,135);
+}
+
+.cursor-dot--hidden {
+    opacity: 0;
 }
 
 body.cursor-enabled,body.cursor-enabled * {

--- a/components/CustomCursor.tsx
+++ b/components/CustomCursor.tsx
@@ -32,12 +32,23 @@ export default function CustomCursor() {
     document.body.classList.add("cursor-enabled");
 
     let raf = 0;
-    let latestX = 0;
-    let latestY = 0;
+    let animationActive = false;
+    const targetPosition = { x: 0, y: 0 };
+    const dotPosition = { x: 0, y: 0 };
+    const cursorPosition = { x: 0, y: 0 };
+    let currentScale = 1;
+    let targetScale = 1;
+    let isHoveringLink = false;
+    let isMouseDown = false;
+
+    const DOT_EASE = 0.22;
+    const CURSOR_EASE = 0.12;
+    const SCALE_EASE = 0.18;
 
     const show = () => {
       dot.style.opacity = "1";
       cursor.style.opacity = "1";
+      startAnimation();
     };
 
     const hide = () => {
@@ -45,31 +56,115 @@ export default function CustomCursor() {
       cursor.style.opacity = "0";
     };
 
-    const update = (scale = 1) => {
+    const applyScaleTarget = () => {
+      targetScale = isMouseDown || isHoveringLink ? 2 : 1;
+      startAnimation();
+    };
+
+    const startAnimation = () => {
+      if (animationActive) {
+        return;
+      }
+
+      animationActive = true;
+      raf = requestAnimationFrame(tick);
+    };
+
+    const stopAnimation = () => {
+      animationActive = false;
       cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => {
-        applyTransform(dot, latestX, latestY);
-        applyTransform(cursor, latestX, latestY, scale);
-      });
+    };
+
+    const tick = () => {
+      dotPosition.x += (targetPosition.x - dotPosition.x) * DOT_EASE;
+      dotPosition.y += (targetPosition.y - dotPosition.y) * DOT_EASE;
+      cursorPosition.x += (targetPosition.x - cursorPosition.x) * CURSOR_EASE;
+      cursorPosition.y += (targetPosition.y - cursorPosition.y) * CURSOR_EASE;
+
+      const scaleDelta = targetScale - currentScale;
+      if (Math.abs(scaleDelta) > 0.01) {
+        currentScale += scaleDelta * SCALE_EASE;
+      } else {
+        currentScale = targetScale;
+      }
+
+      applyTransform(dot, dotPosition.x, dotPosition.y);
+      applyTransform(cursor, cursorPosition.x, cursorPosition.y, currentScale);
+
+      if (animationActive) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+
+    const updatePosition = (x: number, y: number) => {
+      targetPosition.x = x;
+      targetPosition.y = y;
+      startAnimation();
     };
 
     const handleMove = (event: MouseEvent) => {
-      latestX = event.clientX;
-      latestY = event.clientY;
+      updatePosition(event.clientX, event.clientY);
       show();
-      update();
     };
 
     const handleDown = () => {
-      update(0.85);
+      isMouseDown = true;
+      applyScaleTarget();
     };
 
     const handleUp = () => {
-      update();
+      isMouseDown = false;
+      applyScaleTarget();
     };
 
     const handleLeave = () => {
       hide();
+      stopAnimation();
+    };
+
+    const activateLinkHover = () => {
+      if (isHoveringLink) {
+        return;
+      }
+
+      isHoveringLink = true;
+      cursor.classList.add("cursor--link");
+      dot.classList.add("cursor-dot--hidden");
+      applyScaleTarget();
+    };
+
+    const deactivateLinkHover = () => {
+      if (!isHoveringLink) {
+        return;
+      }
+
+      isHoveringLink = false;
+      cursor.classList.remove("cursor--link");
+      dot.classList.remove("cursor-dot--hidden");
+      applyScaleTarget();
+    };
+
+    const handlePointerOver = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      const link = target?.closest("a");
+
+      if (link) {
+        activateLinkHover();
+      }
+    };
+
+    const handlePointerOut = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest("a");
+
+      if (!anchor) {
+        return;
+      }
+
+      const related = event.relatedTarget as HTMLElement | null;
+      if (!related || !anchor.contains(related)) {
+        deactivateLinkHover();
+      }
     };
 
     window.addEventListener("mousemove", handleMove);
@@ -77,15 +172,19 @@ export default function CustomCursor() {
     window.addEventListener("mouseup", handleUp);
     window.addEventListener("mouseenter", show);
     window.addEventListener("mouseleave", handleLeave);
+    document.addEventListener("pointerover", handlePointerOver);
+    document.addEventListener("pointerout", handlePointerOut);
 
     return () => {
       document.body.classList.remove("cursor-enabled");
-      cancelAnimationFrame(raf);
+      stopAnimation();
       window.removeEventListener("mousemove", handleMove);
       window.removeEventListener("mousedown", handleDown);
       window.removeEventListener("mouseup", handleUp);
       window.removeEventListener("mouseenter", show);
       window.removeEventListener("mouseleave", handleLeave);
+      document.removeEventListener("pointerover", handlePointerOver);
+      document.removeEventListener("pointerout", handlePointerOut);
       hide();
     };
   }, []);


### PR DESCRIPTION
## Summary
- smooth the custom cursor and trailing dot using easing-based animation
- add click and link hover scale changes with background and dot opacity updates
- refresh cursor styling to support the new interactive states

## Testing
- npm run lint *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c3efb994832f96f75b7297474683