### PR TITLE
Restore hero monogram variant when clicking outside name

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,6 +122,31 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
     applyHoverVariant();
   }, [applyHoverVariant, restoreVariant]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!storedVariantRef.current || !spanRef.current) {
+        return;
+      }
+
+      const target = event.target as Node | null;
+      if (!target || spanRef.current.contains(target)) {
+        return;
+      }
+
+      restoreVariant();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [restoreVariant]);
+
   return (
     <span
       ref={spanRef}


### PR DESCRIPTION
## Summary
- add a global pointerdown listener to revert the hero monogram back to the framed variant when tapping outside the highlighted name

## Testing
- not run (interactive lint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68e12d815788832f9f54ebc8e8a3ac0a