### PR TITLE
Add progressive word fall animation to site text

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -5,6 +5,8 @@ import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
+import WordFallText from "@/components/WordFallText";
+
 import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
 
 export default function ContactPage() {
@@ -26,6 +28,12 @@ export default function ContactPage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70">
           <div className="page-animate space-y-4" data-hero-index={0}>
+            <WordFallText as="h1" className="text-4xl font-semibold text-fg sm:text-5xl">
+              {t("contact.title")}
+            </WordFallText>
+            <WordFallText as="p" className="text-base text-fg/70 sm:text-lg">
+              {t("contact.subtitle")}
+            </WordFallText>
           </div>
           <form
             onSubmit={handleSubmit}
@@ -34,7 +42,9 @@ export default function ContactPage() {
           >
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span>{t("contact.form.nameLabel")}</span>
+                <WordFallText as="span">
+                  {t("contact.form.nameLabel")}
+                </WordFallText>
                 <input
                   type="text"
                   name="name"
@@ -44,7 +54,9 @@ export default function ContactPage() {
                 />
               </label>
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span>{t("contact.form.emailLabel")}</span>
+                <WordFallText as="span">
+                  {t("contact.form.emailLabel")}
+                </WordFallText>
                 <input
                   type="email"
                   name="email"
@@ -55,7 +67,9 @@ export default function ContactPage() {
               </label>
             </div>
             <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-              <span>{t("contact.form.messageLabel")}</span>
+              <WordFallText as="span">
+                {t("contact.form.messageLabel")}
+              </WordFallText>
               <textarea
                 name="message"
                 required
@@ -69,10 +83,18 @@ export default function ContactPage() {
                 type="submit"
                 className="w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
               >
-                {t("contact.form.submit")}
+                <WordFallText as="span">
+                  {t("contact.form.submit")}
+                </WordFallText>
               </button>
               <div className="min-h-[1.5rem] text-sm text-fg/70" aria-live="polite">
-                {status === "submitted" ? t("contact.form.success") : ""}
+                {status === "submitted" ? (
+                  <WordFallText as="span">
+                    {t("contact.form.success")}
+                  </WordFallText>
+                ) : (
+                  ""
+                )}
               </div>
             </div>
           </form>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2477,3 +2477,33 @@ body.dark .profile-pic-wrapper .profile-pic {
 body.dark .link-underline {
     background-color: #f3f2f9
 }
+
+.falling-words {
+    display: inline;
+}
+
+.falling-words .word-fall {
+    display: inline-block;
+    opacity: 0;
+    transform: translate3d(0, -0.6em, 0);
+    animation: word-fall-down 0.6s forwards;
+}
+
+@keyframes word-fall-down {
+    0% {
+        opacity: 0;
+        transform: translate3d(0, -0.6em, 0);
+    }
+    100% {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .falling-words .word-fall {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 
+import WordFallText from "@/components/WordFallText";
 import {
   HERO_LINE_ONE_MONOGRAM,
   HERO_LINE_TWO_MONOGRAM,
@@ -246,7 +247,10 @@ export default function HomePage() {
                   <div className="intro-wrapper">
                     <div className="intro-text">
                       {/* título 1 */}
-                      <h3 className="intro-id opacity: 1; transform: none;">
+                      <WordFallText
+                        as="h3"
+                        className="intro-id opacity: 1; transform: none;"
+                      >
                         <Trans
                           i18nKey="home.hero.titleLine1"
                           components={{
@@ -255,10 +259,14 @@ export default function HomePage() {
                             ),
                           }}
                         />
-                      </h3>
+                      </WordFallText>
 
                       {/* título 2 */}
-                      <h3 className="intro-id opacity: 1; transform: none;">
+                      <WordFallText
+                        as="h3"
+                        className="intro-id opacity: 1; transform: none;"
+                        initialDelay={0.4}
+                      >
                         <Trans
                           i18nKey="home.hero.titleLine2"
                           components={{
@@ -267,16 +275,24 @@ export default function HomePage() {
                             ),
                           }}
                         />
-                      </h3>
+                      </WordFallText>
 
                       {/* roles */}
                       <div className="intro-roles">
-                        <p className="intro-role opacity: 1; transform: none;">
+                        <WordFallText
+                          as="p"
+                          className="intro-role opacity: 1; transform: none;"
+                          initialDelay={0.8}
+                        >
                           {t("home.hero.role1")}
-                        </p>
-                        <p className="intro-role opacity: 1; transform: none;">
+                        </WordFallText>
+                        <WordFallText
+                          as="p"
+                          className="intro-role opacity: 1; transform: none;"
+                          initialDelay={1.1}
+                        >
                           {t("home.hero.role2")}
-                        </p>
+                        </WordFallText>
                       </div>
 
                       {/* CTAs */}

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useMemo } from "react";
 
+import WordFallText from "./WordFallText";
+
 type MenuProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -69,7 +71,9 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
                 <li key={item.href}>
                   <div className="item-inner" style={itemStyle(i)}>
                     <Link href={item.href} onClick={onClose}>
-                      <h1>{item.label}</h1>
+                      <WordFallText as="h1" delayStep={0.05}>
+                        {item.label}
+                      </WordFallText>
                     </Link>
                   </div>
                 </li>
@@ -87,8 +91,15 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
                     <div className="item-inner" style={itemStyle(items.length + i)}>
                       <div className="link-wrapper">
                         <div className="link">
-                          <a href={s.href} target="_blank" rel="noreferrer" onClick={onClose}>
-                            â†— {s.label}
+                          <a
+                            href={s.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={onClose}
+                          >
+                            <WordFallText as="span" delayStep={0.05}>
+                              ↗ {s.label}
+                            </WordFallText>
                           </a>
                         </div>
                         {/* underline comeÃ§a em -101% exatamente como na referÃªncia/CSS */}

--- a/components/WordFallText.tsx
+++ b/components/WordFallText.tsx
@@ -1,0 +1,115 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useMemo,
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import classNames from "classnames";
+
+type WordFallTextProps<T extends ElementType> = {
+  as?: T;
+  children: ReactNode;
+  className?: string;
+  delayStep?: number;
+  initialDelay?: number;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "children" | "className">;
+
+function isWhitespace(text: string) {
+  return /^\s*$/.test(text);
+}
+
+function createWordSpans(
+  nodes: ReactNode,
+  getDelay: () => string,
+  keyPrefix: string,
+): ReactNode {
+  if (nodes == null || typeof nodes === "boolean") {
+    return null;
+  }
+
+  if (typeof nodes === "string" || typeof nodes === "number") {
+    return String(nodes)
+      .split(/(\s+)/)
+      .map((part, index) => {
+        if (part === "") {
+          return null;
+        }
+
+        if (isWhitespace(part)) {
+          return part;
+        }
+
+        return (
+          <span
+            key={`${keyPrefix}-${index}`}
+            className="word-fall"
+            style={{ animationDelay: getDelay() } as CSSProperties}
+          >
+            {part}
+          </span>
+        );
+      });
+  }
+
+  if (Array.isArray(nodes)) {
+    return nodes.map((child, index) =>
+      createWordSpans(child, getDelay, `${keyPrefix}-${index}`),
+    );
+  }
+
+  if (isValidElement(nodes)) {
+    const element = nodes as ReactElement;
+
+    const processedChildren = createWordSpans(
+      element.props.children,
+      getDelay,
+      `${keyPrefix}-child`,
+    );
+
+    return cloneElement(element, element.props, processedChildren);
+  }
+
+  return nodes;
+}
+
+export default function WordFallText<
+  T extends ElementType = "span",
+>({
+  as,
+  children,
+  className,
+  delayStep = 0.08,
+  initialDelay = 0,
+  ...rest
+}: WordFallTextProps<T>) {
+  const Component = (as ?? "span") as ElementType;
+
+  const getDelayFactory = useMemo(() => {
+    let wordIndex = 0;
+    return () => {
+      const delay = initialDelay + wordIndex * delayStep;
+      wordIndex += 1;
+      return `${delay}s`;
+    };
+  }, [delayStep, initialDelay]);
+
+  const content = useMemo(() => {
+    const getDelay = getDelayFactory;
+    const nodes = Children.toArray(children).map((child, index) =>
+      createWordSpans(child, getDelay, `word-${index}`),
+    );
+
+    return nodes;
+  }, [children, getDelayFactory]);
+
+  return (
+    <Component className={classNames("falling-words", className)} {...rest}>
+      {content}
+    </Component>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable `WordFallText` component that staggers word animation delays
- style the new word fall effect and apply it to hero, contact, and menu copy for progressive reveals

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e135e56f1c832fb945c94fb4c1a2f2