### PR TITLE
Adjust falling text animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2478,21 +2478,17 @@ body.dark .link-underline {
     background-color: #f3f2f9
 }
 
-.falling-words {
-    display: inline;
-}
-
 .falling-words .word-fall {
     display: inline-block;
     opacity: 0;
-    transform: translate3d(0, -0.6em, 0);
-    animation: word-fall-down 0.6s forwards;
+    transform: translate3d(0, -1.25em, 0);
+    animation: word-fall-down 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 @keyframes word-fall-down {
     0% {
         opacity: 0;
-        transform: translate3d(0, -0.6em, 0);
+        transform: translate3d(0, -1.25em, 0);
     }
     100% {
         opacity: 1;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -301,7 +301,11 @@ export default function HomePage() {
                           <li className="opacity: 1">
                             <div className="link-wrapper">
                               <div className="link">
-                                <a href="/work">{t("home.hero.ctaProjects")}</a>
+                                <a href="/work">
+                                  <WordFallText as="span" initialDelay={1.3}>
+                                    {t("home.hero.ctaProjects")}
+                                  </WordFallText>
+                                </a>
                               </div>
                               <div className="link-underline transform: translateX(-101%) translateZ(0px);" />
                             </div>
@@ -309,7 +313,11 @@ export default function HomePage() {
                           <li className="opacity: 1">
                             <div className="link-wrapper">
                               <div className="link">
-                                <a href="/about">{t("home.hero.ctaAbout")}</a>
+                                <a href="/about">
+                                  <WordFallText as="span" initialDelay={1.3}>
+                                    {t("home.hero.ctaAbout")}
+                                  </WordFallText>
+                                </a>
                               </div>
                               <div className="link-underline" />
                             </div>


### PR DESCRIPTION
## Summary
- randomize WordFallText delays so words fall in a shuffled order across nested elements
- tweak the falling animation to drop from higher above with eased timing for a softer effect
- wrap hero call-to-action links with WordFallText so they share the falling animation

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e13838700c832f9597bf3f7c693339