### PR TITLE
Improve preloader flow and fall-down animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2480,8 +2480,8 @@ body.dark .link-underline {
 
 .fall-down-element {
     opacity: 0;
-    transform: translateY(-96px);
-    animation: fall-down 0.6s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+    transform: translateY(calc(var(--fall-distance, 64px) * -1));
+    animation: fall-down var(--fall-duration, 0.8s) cubic-bezier(0.22, 1, 0.36, 1) forwards;
     animation-delay: var(--fall-delay, 0s);
     will-change: transform, opacity;
 }
@@ -2489,12 +2489,17 @@ body.dark .link-underline {
 @keyframes fall-down {
     0% {
         opacity: 0;
-        transform: translateY(-96px);
+        transform: translateY(calc(var(--fall-distance, 64px) * -1));
+    }
+
+    60% {
+        opacity: 1;
+        transform: translateY(calc(var(--fall-distance, 64px) * 0.12));
     }
 
     100% {
         opacity: 1;
-        transform: none;
+        transform: translateY(0);
     }
 }
 


### PR DESCRIPTION
## Summary
- smooth out the preloader by animating progress, enforcing a minimum display time, and keeping the overlay visible until completion
- tweak the fall-down animation easing and distance for a softer, more progressive reveal while keeping the preloader container fixed

## Testing
- not run (npm run lint prompts for interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68e144dc7d8c832fab1e5cc12d7bae0f