### PR TITLE
Implement sequential entrance animation and repair preloader markup

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState, type CSSProperties } from "react";
+import { FormEvent, useState } from "react";
 import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
@@ -26,14 +26,11 @@ export default function ContactPage() {
       <main className="relative z-10 flex min-h-screen w-full flex-col">
         <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70">
           <div className="page-animate space-y-4" data-hero-index={0}>
-            <h1
-              className="fall-down-element text-4xl font-semibold text-fg sm:text-5xl"
-            >
+            <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
               {t("contact.title")}
             </h1>
             <p
-              className="fall-down-element text-base text-fg/70 sm:text-lg"
-              style={{ "--fall-delay": "0.2s" } as CSSProperties}
+              className="text-base text-fg/70 sm:text-lg"
             >
               {t("contact.subtitle")}
             </p>
@@ -45,9 +42,7 @@ export default function ContactPage() {
           >
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span className="fall-down-element">
-                  {t("contact.form.nameLabel")}
-                </span>
+                <span>{t("contact.form.nameLabel")}</span>
                 <input
                   type="text"
                   name="name"
@@ -57,9 +52,7 @@ export default function ContactPage() {
                 />
               </label>
               <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span className="fall-down-element" style={{ "--fall-delay": "0.2s" } as CSSProperties}>
-                  {t("contact.form.emailLabel")}
-                </span>
+                <span>{t("contact.form.emailLabel")}</span>
                 <input
                   type="email"
                   name="email"
@@ -70,9 +63,7 @@ export default function ContactPage() {
               </label>
             </div>
             <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-              <span className="fall-down-element" style={{ "--fall-delay": "0.3s" } as CSSProperties}>
-                {t("contact.form.messageLabel")}
-              </span>
+              <span>{t("contact.form.messageLabel")}</span>
               <textarea
                 name="message"
                 required
@@ -84,14 +75,13 @@ export default function ContactPage() {
             <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
               <button
                 type="submit"
-                className="fall-down-element w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
-                style={{ "--fall-delay": "0.4s" } as CSSProperties}
+                className="w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
               >
                 {t("contact.form.submit")}
               </button>
               <div className="min-h-[1.5rem] text-sm text-fg/70" aria-live="polite">
                 {status === "submitted" ? (
-                  <span className="fall-down-element" style={{ "--fall-delay": "0.5s" } as CSSProperties}>
+                  <span>
                     {t("contact.form.success")}
                   </span>
                 ) : (

--- a/app/globals.css
+++ b/app/globals.css
@@ -2478,31 +2478,3 @@ body.dark .profile-pic-wrapper .profile-pic {
 body.dark .link-underline {
     background-color: #f3f2f9
 }
-
-.fall-down-element {
-    opacity: 0;
-    transform: translateY(-96px);
-    animation: fall-down 0.6s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
-    animation-delay: var(--fall-delay, 0s);
-    will-change: transform, opacity;
-}
-
-@keyframes fall-down {
-    0% {
-        opacity: 0;
-        transform: translateY(-96px);
-    }
-
-    100% {
-        opacity: 1;
-        transform: none;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .fall-down-element {
-        animation: none !important;
-        opacity: 1 !important;
-        transform: none !important;
-    }
-}

--- a/app/helpers/useSequentialReveal.ts
+++ b/app/helpers/useSequentialReveal.ts
@@ -1,0 +1,151 @@
+"use client";
+
+import { RefObject, useEffect, useLayoutEffect, useRef } from "react";
+
+interface Options {
+  distance?: number;
+  duration?: number;
+  delayStep?: number;
+}
+
+const DEFAULT_DISTANCE = 100;
+const DEFAULT_DURATION = 600;
+const DEFAULT_DELAY_STEP = 50;
+
+type AnimationState = "enter" | "exit";
+
+const getReduceMotionPreference = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+};
+
+const orderElements = (elements: HTMLElement[]) => {
+  return elements
+    .map((element) => ({
+      element,
+      rect: element.getBoundingClientRect(),
+    }))
+    .sort((a, b) => {
+      const rowDiff = a.rect.top - b.rect.top;
+
+      if (Math.abs(rowDiff) > 16) {
+        return rowDiff;
+      }
+
+      return a.rect.left - b.rect.left;
+    })
+    .map(({ element }) => element);
+};
+
+const resetElementStyles = (element: HTMLElement) => {
+  element.style.removeProperty("transition-property");
+  element.style.removeProperty("transition-duration");
+  element.style.removeProperty("transition-delay");
+  element.style.removeProperty("transition-timing-function");
+  element.style.removeProperty("opacity");
+  element.style.removeProperty("transform");
+  element.style.removeProperty("will-change");
+};
+
+const applyAnimationState = (
+  elements: HTMLElement[],
+  state: AnimationState,
+  immediate: boolean,
+  options?: Options,
+) => {
+  if (!elements.length) {
+    return;
+  }
+
+  const reduceMotion = getReduceMotionPreference();
+  const distance = options?.distance ?? DEFAULT_DISTANCE;
+  const duration = options?.duration ?? DEFAULT_DURATION;
+  const delayStep = options?.delayStep ?? DEFAULT_DELAY_STEP;
+  const total = elements.length;
+
+  elements.forEach((element, index) => {
+    if (reduceMotion) {
+      element.style.transitionProperty = "none";
+      element.style.transitionDuration = "0ms";
+      element.style.transitionDelay = "0ms";
+      element.style.removeProperty("transition-timing-function");
+      element.style.removeProperty("will-change");
+    } else {
+      const delayIndex = state === "enter" ? index : total - 1 - index;
+
+      element.style.transitionProperty = "transform, opacity";
+      element.style.transitionTimingFunction =
+        "cubic-bezier(0.22, 0.61, 0.36, 1)";
+      element.style.transitionDuration = immediate
+        ? "0ms"
+        : `${duration}ms`;
+      element.style.transitionDelay = immediate
+        ? "0ms"
+        : `${delayIndex * delayStep}ms`;
+      element.style.willChange = "transform, opacity";
+    }
+
+    element.style.opacity = state === "enter" ? "1" : "0";
+    element.style.transform =
+      state === "enter" ? "none" : `translateY(-${distance}px)`;
+  });
+};
+
+export default function useSequentialReveal(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+  options?: Options,
+) {
+  const elementsRef = useRef<HTMLElement[]>([]);
+  const hasSetupRef = useRef(false);
+
+  const distance = options?.distance;
+  const duration = options?.duration;
+  const delayStep = options?.delayStep;
+
+  useLayoutEffect(() => {
+    const root = ref.current;
+
+    if (!root) {
+      return;
+    }
+
+    const descendants = Array.from(root.querySelectorAll("*"));
+    const candidates = [root, ...descendants].filter(
+      (node): node is HTMLElement => node instanceof HTMLElement,
+    );
+
+    const ordered = orderElements(candidates);
+    elementsRef.current = ordered;
+    hasSetupRef.current = true;
+
+    applyAnimationState(ordered, "exit", true, options);
+
+    return () => {
+      ordered.forEach(resetElementStyles);
+      elementsRef.current = [];
+      hasSetupRef.current = false;
+    };
+  }, [ref, distance, duration, delayStep]);
+
+  useEffect(() => {
+    if (!hasSetupRef.current) {
+      return;
+    }
+
+    const elements = elementsRef.current;
+
+    if (!elements.length) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      applyAnimationState(elements, active ? "enter" : "exit", false, options);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [active, distance, duration, delayStep]);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,7 @@
 import { useTranslation, Trans } from "react-i18next";
 import "./i18n/config";
 import { useThreeSceneSetup } from "./helpers/useThreeSceneSetup";
-import {
-  useEffect,
-  PropsWithChildren,
-  useCallback,
-  useRef,
-  type CSSProperties,
-} from "react";
+import { useEffect, PropsWithChildren, useCallback, useRef } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 
 import {
@@ -151,8 +145,7 @@ function NameWithWave({ children, hoverVariant }: NameWithWaveProps) {
   return (
     <span
       ref={spanRef}
-      className="name fall-down-element"
-      style={{ "--fall-delay": "0.1s" } as CSSProperties}
+      className="name"
       data-cursor-interactive
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}
@@ -248,9 +241,7 @@ export default function HomePage() {
                   <div className="intro-wrapper">
                     <div className="intro-text">
                       {/* título 1 */}
-                      <h3
-                        className="intro-id fall-down-element opacity: 1; transform: none;"
-                      >
+                      <h3 className="intro-id opacity: 1; transform: none;">
                         <Trans
                           i18nKey="home.hero.titleLine1"
                           components={{
@@ -262,10 +253,7 @@ export default function HomePage() {
                       </h3>
 
                       {/* título 2 */}
-                      <h3
-                        className="intro-id fall-down-element opacity: 1; transform: none;"
-                        style={{ "--fall-delay": "0.4s" } as CSSProperties}
-                      >
+                      <h3 className="intro-id opacity: 1; transform: none;">
                         <Trans
                           i18nKey="home.hero.titleLine2"
                           components={{
@@ -278,16 +266,10 @@ export default function HomePage() {
 
                       {/* roles */}
                       <div className="intro-roles">
-                        <p
-                          className="intro-role fall-down-element opacity: 1; transform: none;"
-                          style={{ "--fall-delay": "0.8s" } as CSSProperties}
-                        >
+                        <p className="intro-role opacity: 1; transform: none;">
                           {t("home.hero.role1")}
                         </p>
-                        <p
-                          className="intro-role fall-down-element opacity: 1; transform: none;"
-                          style={{ "--fall-delay": "1.1s" } as CSSProperties}
-                        >
+                        <p className="intro-role opacity: 1; transform: none;">
                           {t("home.hero.role2")}
                         </p>
                       </div>
@@ -299,10 +281,7 @@ export default function HomePage() {
                             <div className="link-wrapper">
                               <div className="link">
                                 <a href="/work">
-                                  <span
-                                    className="fall-down-element"
-                                    style={{ "--fall-delay": "1.3s" } as CSSProperties}
-                                  >
+                                  <span>
                                     {t("home.hero.ctaProjects")}
                                   </span>
                                 </a>
@@ -314,10 +293,7 @@ export default function HomePage() {
                             <div className="link-wrapper">
                               <div className="link">
                                 <a href="/about">
-                                  <span
-                                    className="fall-down-element"
-                                    style={{ "--fall-delay": "1.3s" } as CSSProperties}
-                                  >
+                                  <span>
                                     {t("home.hero.ctaAbout")}
                                   </span>
                                 </a>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ReactNode, useCallback, useEffect, useState, type CSSProperties } from "react";
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import useSequentialReveal from "@/app/helpers/useSequentialReveal";
 import Preloader from "./Preloader";
 import CanvasRoot from "./three/CanvasRoot";
 
@@ -12,6 +19,7 @@ export default function AppShell({ children }: AppShellProps) {
   const [isReady, setIsReady] = useState(false);
   const [canRenderContent, setCanRenderContent] = useState(false);
   const [isContentVisible, setIsContentVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const handleComplete = useCallback(() => {
     setIsReady(true);
@@ -33,18 +41,16 @@ export default function AppShell({ children }: AppShellProps) {
     return () => cancelAnimationFrame(id);
   }, [isReady]);
 
+  useSequentialReveal(containerRef, isContentVisible);
+
   return (
     <div className="relative min-h-screen w-full overflow-hidden">
       {!isReady && <Preloader onComplete={handleComplete} />}
       <CanvasRoot isReady={isReady} />
       {canRenderContent ? (
         <div
-          className={`fall-down-element ${
-            isContentVisible
-              ? "visible opacity-100"
-              : "pointer-events-none invisible opacity-0"
-          }`}
-          style={{ "--fall-delay": "0.3s" } as CSSProperties}
+          ref={containerRef}
+          className={isContentVisible ? "" : "pointer-events-none"}
           aria-hidden={!isContentVisible}
           aria-busy={!isContentVisible}
         >

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useState } from "react";
 import i18n from "@/app/i18n/config";
 
 export default function LanguageSwitcher() {
@@ -22,8 +22,6 @@ export default function LanguageSwitcher() {
         e.preventDefault();
         i18n.changeLanguage(target);
       }}
-      className="fall-down-element"
-      style={{ "--fall-delay": "0.2s" } as CSSProperties}
     >
       {target.toUpperCase()}
     </a>

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -61,7 +61,7 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
       aria-modal="true"
       aria-hidden={!isOpen}
     >
-      <div className="menu-content fall-down-element" style={{ "--fall-delay": isOpen ? "0.05s" : "0s" } as CSSProperties}>
+      <div className="menu-content">
         <div className="menu-items">
           <nav>
             <ol>
@@ -69,9 +69,7 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
                 <li key={item.href}>
                   <div className="item-inner" style={itemStyle(i)}>
                     <Link href={item.href} onClick={onClose}>
-                      <span className="fall-down-element" style={{ "--fall-delay": `${i * 0.05}s` } as CSSProperties}>
-                        {item.label}
-                      </span>
+                      <span>{item.label}</span>
                     </Link>
                   </div>
                 </li>
@@ -95,12 +93,7 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
                             rel="noreferrer"
                             onClick={onClose}
                           >
-                            <span
-                              className="fall-down-element"
-                              style={{ "--fall-delay": `${(items.length + i) * 0.05}s` } as CSSProperties}
-                            >
-                              ↗ {s.label}
-                            </span>
+                          <span>↗ {s.label}</span>
                           </a>
                         </div>
                         {/* underline comeÃ§a em -101% exatamente como na referÃªncia/CSS */}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import Menu from "./Menu";
 import LanguageSwitcher from "./LanguageSwitcher";
@@ -31,11 +31,11 @@ export default function Navbar() {
 
   return (
     <>
-      <header className="fall-down-element" style={{ "--fall-delay": "0.1s" } as CSSProperties}>
-        <div className="header-content fall-down-element" style={{ "--fall-delay": "0.15s" } as CSSProperties}>
+      <header>
+        <div className="header-content">
           {/* LEFT */}
-          <div className="left-part flex transform-none fall-down-element" style={{ "--fall-delay": "0.2s" } as CSSProperties}>
-            <div className="logo fall-down-element" style={{ "--fall-delay": "0.25s" } as CSSProperties}>
+          <div className="left-part flex transform-none">
+            <div className="logo">
               <Link href="/" aria-label="Home">
                 <span className="visually-hidden">Home</span>
                 <svg
@@ -67,10 +67,7 @@ export default function Navbar() {
           </div>
 
           {/* RIGHT */}
-          <div
-            className="right-part fall-down-element"
-            style={{ display: "flex", transform: "none", "--fall-delay": "0.3s" } as CSSProperties}
-          >
+          <div className="right-part" style={{ display: "flex", transform: "none" }}>
             <ul>
               {/* LanguageSwitcher no lugar do EN/PT estático */}
               <li
@@ -91,8 +88,7 @@ export default function Navbar() {
               {/* Botão do menu (9 pontos) */}
               <li>
                 <button
-                  className="hamburger-btn fall-down-element"
-                  style={{ "--fall-delay": "0.35s" } as CSSProperties}
+                  className="hamburger-btn"
                   type="button"
                   aria-haspopup="dialog"
                   aria-expanded={isOpen}

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -241,7 +241,80 @@ export default function Preloader({ onComplete }: PreloaderProps) {
     ? STATIC_PREVIEW_STYLES
     : "h-48 w-48 animate-pulse rounded-full bg-fg/10";
 
+  const statusLabel = t(`preloader.status.${statusKey}`);
+  const progressLabel = Math.round(progress);
+  const isHidden = statusKey === "ready";
+  const splashStyle: CSSProperties = {
+    opacity: isHidden ? 0 : 1,
+    display: isHidden ? "none" : "flex",
+  };
+
   return (
-    <div class="splashscreen" style="opacity: 0; display: none;"><div style="transform: none;"><svg data-name="deconstructedLogo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72" width="72" height="72" class="icons-style"><circle id="Sphere" cx="31.019" cy="18.93" r="3.555" opacity="0" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="1px 1px" style="transform: translateY(-96px) rotate(0deg); transform-origin: 31.019px 18.93px;" transform-origin="31.018998861312866px 18.930000066757202px"></circle><path id="Magnet1" d="M61.028,23.378a3.555,3.555,0,0,0-6.682-2.432,4.39,4.39,0,0,1-8.25-3,3.555,3.555,0,1,0-6.682-2.432,11.5,11.5,0,0,0,21.614,7.867Z" opacity="0" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="1px 1px" style="transform: translateY(-96px) rotate(0deg); transform-origin: 49.9814px 22.0613px;" transform-origin="49.981407165527344px 22.061344146728516px"></path><path id="Wave" d="M24.221,27.153a4.387,4.387,0,0,1-5.607-1.76A11.436,11.436,0,0,0,13.56,20.8a3.555,3.555,0,1,0-3.005,6.444,4.358,4.358,0,0,1,1.925,1.748,11.5,11.5,0,0,0,14.7,4.627,4.389,4.389,0,0,1,5.608,1.759,11.43,11.43,0,0,0,5.053,4.595,3.556,3.556,0,0,0,3.006-6.445,4.353,4.353,0,0,1-1.926-1.747,11.5,11.5,0,0,0-14.7-4.627Z" opacity="0" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="1px 1px" style="transform: translateY(-96px) rotate(0deg); transform-origin: 25.683px 30.3782px;" transform-origin="25.68295192718506px 30.378185272216797px"></path><path id="Magnet2" d="M13.411,43.392a3.555,3.555,0,0,0,5.825,4.078,4.39,4.39,0,1,1,7.191,5.036,3.555,3.555,0,0,0,5.825,4.078A11.5,11.5,0,1,0,13.411,43.392Z" opacity="0" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="1px 1px" style="transform: translateY(-96px) rotate(0deg); transform-origin: 23.5515px 48.2918px;" transform-origin="23.55152416229248px 48.29178047180176px"></path><path id="OpenLoop" d="M61.5,47.329A11.5,11.5,0,0,0,50,35.829a3.556,3.556,0,1,0,0,7.111,4.389,4.389,0,1,1-4.39,4.389,3.556,3.556,0,0,0-7.111,0,11.5,11.5,0,0,0,23,0Z" opacity="0" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="1px 1px" style="transform: translateY(-96px) rotate(0deg); transform-origin: 49.9995px 47.3288px;" transform-origin="49.9995002746582px 47.32875061035156px"></path></svg></div><div class="loading-text-wrapper"><p class="loading-text" style="opacity: 0; transform: translateY(-96px) translateZ(0px);">Materializing shapes<!-- -->...</p></div><div class="credits"><p style="opacity: 0; transform: translateY(-96px) translateZ(0px);">Designed and coded by Sharlee<!-- --> © <!-- -->2025</p></div></div>
+    <div className="splashscreen" style={splashStyle} aria-hidden={isHidden}>
+      <div className={previewClassName} aria-hidden="true">
+        <PreloaderLogo />
+      </div>
+      <div className="loading-text-wrapper" aria-live="polite">
+        <p className="loading-text">{t("preloader.title")}</p>
+        <p className="visually-hidden">
+          {t("preloader.progress", { value: progressLabel })}
+        </p>
+        <p className="visually-hidden">{statusLabel}</p>
+      </div>
+      <div className="credits">
+        <p>Designed and coded by Sharlee © 2025</p>
+      </div>
+    </div>
+  );
+}
+
+function PreloaderLogo() {
+  return (
+    <svg
+      data-name="deconstructedLogo"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 72 72"
+      width="72"
+      height="72"
+      className="icons-style"
+    >
+      <circle
+        id="Sphere"
+        cx="31.019"
+        cy="18.93"
+        r="3.555"
+        pathLength={1}
+        strokeDashoffset="0px"
+        strokeDasharray="1px 1px"
+      />
+      <path
+        id="Magnet1"
+        d="M61.028,23.378a3.555,3.555,0,0,0-6.682-2.432,4.39,4.39,0,0,1-8.25-3,3.555,3.555,0,1,0-6.682-2.432,11.5,11.5,0,0,0,21.614,7.867Z"
+        pathLength={1}
+        strokeDashoffset="0px"
+        strokeDasharray="1px 1px"
+      />
+      <path
+        id="Wave"
+        d="M24.221,27.153a4.387,4.387,0,0,1-5.607-1.76A11.436,11.436,0,0,0,13.56,20.8a3.555,3.555,0,1,0-3.005,6.444,4.358,4.358,0,0,1,1.925,1.748,11.5,11.5,0,0,0,14.7,4.627,4.389,4.389,0,0,1,5.608,1.759,11.43,11.43,0,0,0,5.053,4.595,3.556,3.556,0,0,0,3.006-6.445,4.353,4.353,0,0,1-1.926-1.747,11.5,11.5,0,0,0-14.7-4.627Z"
+        pathLength={1}
+        strokeDashoffset="0px"
+        strokeDasharray="1px 1px"
+      />
+      <path
+        id="Magnet2"
+        d="M13.411,43.392a3.555,3.555,0,0,0,5.825,4.078,4.39,4.39,0,1,1,7.191,5.036,3.555,3.555,0,0,0,5.825,4.078A11.5,11.5,0,1,0,13.411,43.392Z"
+        pathLength={1}
+        strokeDashoffset="0px"
+        strokeDasharray="1px 1px"
+      />
+      <path
+        id="OpenLoop"
+        d="M61.5,47.329A11.5,11.5,0,0,0,50,35.829a3.556,3.556,0,1,0,0,7.111,4.389,4.389,0,1,1-4.39,4.389,3.556,3.556,0,0,0-7.111,0,11.5,11.5,0,0,0,23,0Z"
+        pathLength={1}
+        strokeDashoffset="0px"
+        strokeDasharray="1px 1px"
+      />
+    </svg>
   );
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useState } from "react";
 
 import { useTheme } from "@/app/theme/ThemeContext";
 import { useTranslation } from "react-i18next";
@@ -22,8 +22,7 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      className="theme-switch-btn fall-down-element"
-      style={{ "--fall-delay": "0.25s" } as CSSProperties}
+      className="theme-switch-btn"
       aria-label={t("themeToggle.ariaLabel", { theme: t(`themeToggle.themes.${nextThemeKey}`) })}
       aria-pressed={theme === "dark"}
       title={t("themeToggle.title", { theme: t(`themeToggle.themes.${theme}`) })}


### PR DESCRIPTION
## Summary
- replace the per-element fall-down classes with a sequential reveal hook and remove the legacy CSS animation
- update the shell, navbar, menu, and pages to rely on the global animation sequence instead of inline fall-down delays
- fix the preloader markup so it renders valid React elements and surfaces the existing translation strings

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e14d926d58832f8dcc0c3480510c40