### PR TITLE
Fix fall animation typing for global animator

### DIFF
--- a/components/GlobalFallAnimator.tsx
+++ b/components/GlobalFallAnimator.tsx
@@ -23,7 +23,7 @@ function computeDelay(index: number) {
   return Math.min(index, MAX_STAGGER_STEPS) * ITEM_STAGGER_DELAY;
 }
 
-function setDelay(el: Element, delay: number) {
+function setDelay(el: HTMLElement | SVGElement, delay: number) {
   if ("style" in el && el.style) {
     el.style.setProperty("--fall-delay", `${delay}ms`);
   }


### PR DESCRIPTION
## Summary
- update the fall delay helper to work with elements that expose a style declaration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1625fa2ac832facf4ea565cabcd68