### PR TITLE
Implement preloader-controlled fall animation flow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -313,6 +313,12 @@ body.dark header {
     mix-blend-mode: difference
 }
 
+body[data-preloading="true"] header,
+body[data-preloading="true"] main {
+    opacity: 0;
+    pointer-events: none
+}
+
 .fall-animated {
     opacity: 0;
     translate: 0 -100px;
@@ -355,7 +361,8 @@ body.dark header {
     padding: var(--top-internal-margin) var(--left-right-margin);
     align-items: center;
     justify-content: center;
-    row-gap: var(--top-internal-margin)
+    row-gap: var(--top-internal-margin);
+    background-color: rgb(var(--color-bg) / 1)
 }
 
 .splashscreen .loading-text-wrapper {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,6 +28,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ThemeScript />
       </head>
       <body
+        data-preloading="true"
         className={classNames(
           "bg-bg text-fg antialiased selection:bg-white/20 dark:selection:bg-white/10",
         )}
@@ -36,8 +37,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <I18nProvider lang={lang}>
             <GlobalFallAnimator />
             <CustomCursor />
-            <Navbar />
-            <AppShell>{children}</AppShell>
+            <AppShell navbar={<Navbar />}>{children}</AppShell>
           </I18nProvider>
         </ThemeProvider>
       </body>

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -250,7 +250,12 @@ export default function Preloader({ onComplete }: PreloaderProps) {
   };
 
   return (
-    <div className="splashscreen" style={splashStyle} aria-hidden={isHidden}>
+    <div
+      className="splashscreen"
+      style={splashStyle}
+      aria-hidden={isHidden}
+      data-preloader-root="true"
+    >
       <div className={previewClassName} aria-hidden="true">
         <PreloaderLogo />
       </div>


### PR DESCRIPTION
## Summary
- render the navbar through AppShell and mark the body as preloading so the initial reveal matches the menu animation
- coordinate GlobalFallAnimator with a preloader reveal event to defer fall-enter classes until the splash finishes
- style the splash screen background and tag the preloader root so it animates independently while the rest of the page waits

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e16a803a34832f8e70d6618b6afa0d