### PR TITLE
Skip fall animation for canvas background

### DIFF
--- a/components/three/CanvasRoot.tsx
+++ b/components/three/CanvasRoot.tsx
@@ -40,6 +40,7 @@ export default function CanvasRoot({ isReady }: CanvasRootProps) {
         isVisible ? "opacity-100" : "opacity-0",
       )}
       aria-hidden={!isVisible}
+      data-fall-skip="true"
     >
       <div className="relative h-full w-full">
         <div className="absolute inset-0 z-0">


### PR DESCRIPTION
## Summary
- mark the background canvas container to skip the global fall-down animation so the effect only applies to foreground elements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1714a2c00832f86eafcceed6e3c42