### PR TITLE
Refine fall animation targeting and preload sequence

### DIFF
--- a/components/CustomCursor.tsx
+++ b/components/CustomCursor.tsx
@@ -236,8 +236,18 @@ export default function CustomCursor() {
 
   return (
     <>
-      <div ref={dotRef} className="cursor-dot" />
-      <div ref={cursorRef} className="cursor" />
+      <div
+        ref={dotRef}
+        className="cursor-dot"
+        data-fall-skip="true"
+        aria-hidden="true"
+      />
+      <div
+        ref={cursorRef}
+        className="cursor"
+        data-fall-skip="true"
+        aria-hidden="true"
+      />
     </>
   );
 }

--- a/components/Noise.tsx
+++ b/components/Noise.tsx
@@ -1,3 +1,3 @@
 export default function Noise() {
-    return <div className="noise" />;
+  return <div className="noise" data-fall-skip="true" aria-hidden="true" />;
 }

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -260,7 +260,9 @@ export default function Preloader({ onComplete }: PreloaderProps) {
         <PreloaderLogo />
       </div>
       <div className="loading-text-wrapper" aria-live="polite">
-        <p className="loading-text">{t("preloader.title")}</p>
+        <p className="loading-text">
+          <FallWordFragments text={t("preloader.title")} />
+        </p>
         <p className="visually-hidden">
           {t("preloader.progress", { value: progressLabel })}
         </p>
@@ -270,6 +272,25 @@ export default function Preloader({ onComplete }: PreloaderProps) {
         <p>Designed and coded by Matheus Duarte © 2025</p>
       </div>
     </div>
+  );
+}
+
+function FallWordFragments({ text }: { text: string }) {
+  const parts = text.split(/\s+/).filter(Boolean);
+
+  return (
+    <>
+      {parts.map((part, index) => (
+        <span
+          key={`${part}-${index}`}
+          data-fall-target="true"
+          style={{ display: "inline-block" }}
+        >
+          {part}
+          {index < parts.length - 1 ? "\u00A0" : ""}
+        </span>
+      ))}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- tighten GlobalFallAnimator filtering so only meaningful content (text/icon nodes) receives the fall animation while backgrounds and hidden helpers are ignored
- split the preloader headline into individually animated word spans to mirror the menu cascade entrance
- flag noise and custom cursor overlays to skip the global fall effect and keep the background static

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e2aae1486c832f9a3f7b443b60d956