### PR TITLE
Align fall animations with menu transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -321,22 +321,22 @@ body[data-preloading="true"] main {
 
 .fall-animated {
     opacity: 0;
-    translate: 0 -100px;
+    transform: translateY(-100px) translateZ(0);
     transition:
-        translate .4s cubic-bezier(.22,.61,.36,1),
+        transform .4s cubic-bezier(.22,.61,.36,1),
         opacity .4s cubic-bezier(.22,.61,.36,1);
     transition-delay: var(--fall-delay, 0ms);
-    will-change: translate, opacity
+    will-change: transform, opacity
 }
 
 .fall-animated.fall-enter {
     opacity: 1;
-    translate: 0 0
+    transform: translateY(0) translateZ(0)
 }
 
 .fall-animated.fall-exit {
     opacity: 0;
-    translate: 0 -100px
+    transform: translateY(-100px) translateZ(0)
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -345,7 +345,7 @@ body[data-preloading="true"] main {
     .fall-animated.fall-exit {
         transition: none !important;
         opacity: 1 !important;
-        translate: 0 0 !important
+        transform: none !important
     }
 }
 


### PR DESCRIPTION
## Summary
- update the global fall animation to use the same transform-based transition as the menu open/close effect
- adjust reduced-motion handling and will-change hints to match the menu animation behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2af9f5b6c832f8f6f2fa42f4230aa