### PR TITLE
Disable custom cursor on touch devices and smooth preloader fade-out

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,18 @@ body.dark .cursor {
     mix-blend-mode: difference
 }
 
+@media (pointer: coarse), (max-width: 63.99em) {
+    .cursor,
+    .cursor-dot {
+        display: none !important
+    }
+
+    body.cursor-enabled,
+    body.cursor-enabled * {
+        cursor: auto !important
+    }
+}
+
 body.dark .cursor-dot {
     background-color: #f3f2f9;
     mix-blend-mode: difference
@@ -363,6 +375,12 @@ body[data-preloading="true"] main {
     justify-content: center;
     row-gap: var(--top-internal-margin);
     background-color: rgb(var(--color-bg) / 1);
+    transition: opacity .45s cubic-bezier(.22,.61,.36,1);
+}
+
+.splashscreen[data-state="hiding"] {
+    opacity: 0;
+    pointer-events: none
 }
 
 .splashscreen .loading-text-wrapper {

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -22,7 +22,7 @@ type PreloaderProps = {
 const STATIC_PREVIEW_STYLES = "h-48 w-48 rounded-full bg-fg/10";
 const INITIAL_PROGRESS = 12;
 const MIN_VISIBLE_TIME = 900;
-const READY_EXIT_BUFFER = 200;
+const READY_EXIT_BUFFER = 450;
 
 export default function Preloader({ onComplete }: PreloaderProps) {
   const [statusKey, setStatusKey] = useState<PreloaderStatus>("fonts");
@@ -67,6 +67,8 @@ export default function Preloader({ onComplete }: PreloaderProps) {
     const elapsed = now - mountTimeRef.current;
     const remaining = Math.max(MIN_VISIBLE_TIME - elapsed, 0);
     const readyDelay = Math.max(remaining - READY_EXIT_BUFFER, 0);
+
+    setTargetProgress(100);
 
     if (readyDelay > 0) {
       readyTimeoutRef.current = window.setTimeout(() => {
@@ -243,17 +245,17 @@ export default function Preloader({ onComplete }: PreloaderProps) {
 
   const statusLabel = t(`preloader.status.${statusKey}`);
   const progressLabel = Math.round(progress);
-  const isHidden = statusKey === "ready";
-  const splashStyle: CSSProperties = {
-    opacity: isHidden ? 0 : 1,
-    display: isHidden ? "none" : "flex",
-  };
+  const isHiding = statusKey === "ready";
+  const splashStyle: CSSProperties = isHiding
+    ? { opacity: 0, pointerEvents: "none" }
+    : { opacity: 1 };
 
   return (
     <div
       className="splashscreen"
       style={splashStyle}
-      aria-hidden={isHidden}
+      data-state={isHiding ? "hiding" : "visible"}
+      aria-hidden={isHiding}
       data-preloader-root="true"
     >
       <div className={previewClassName} aria-hidden="true">


### PR DESCRIPTION
## Summary
- gate the custom cursor to desktop fine pointers and remove it on mobile/tablet breakpoints
- smooth the preloader dismissal with a fade-out transition and extend the exit buffer
- ensure the preloader progress reaches completion while the overlay fades away

## Testing
- not run (Next.js `next lint` requires interactive setup in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2b3eccb8c832fb7b7eaafa24155ca