### PR TITLE
Align home and preloader animations with menu fall effect

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,16 @@
 import { useTranslation, Trans } from "react-i18next";
 import "./i18n/config";
 import { useThreeSceneSetup } from "./helpers/useThreeSceneSetup";
-import { useEffect, PropsWithChildren, useCallback, useRef } from "react";
+import {
+  useEffect,
+  PropsWithChildren,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import Noise from "@/components/Noise";
+import { useReducedMotion } from "framer-motion";
+import { getFallItemStyle } from "@/components/fallAnimation";
 
 import {
   HERO_LINE_ONE_MONOGRAM,
@@ -224,25 +231,48 @@ export default function HomePage() {
   }, []);
 
   const { t } = useTranslation("common");
+  const prefersReducedMotion = useReducedMotion();
+  const disableFallAnimation = Boolean(prefersReducedMotion);
+  const [isFallActive, setIsFallActive] = useState(disableFallAnimation);
+
+  useEffect(() => {
+    if (disableFallAnimation) {
+      setIsFallActive(true);
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      setIsFallActive(true);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [disableFallAnimation]);
+
+  const totalFallItems = 6;
+  const fallStyle = (index: number) =>
+    getFallItemStyle(isFallActive, index, totalFallItems, {
+      disable: disableFallAnimation,
+    });
+
   useThreeSceneSetup("home", { opacity: 1 });
 
   return (
     <>
-      <main className="w-front h-front relative z-30">
-        <div className="opacity: 1; transform: none;">
+      <main className="w-front h-front relative z-30" data-fall-skip="true">
+        <div>
           <div data-scroll-container="true" id="scroll-container">
             <div
               data-scroll-section="true"
               data-scroll-section-id="section0"
               data-scroll-section-inview=""
-              className="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); opacity: 1; pointer-events: all;"
+              className="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);"
             >
-              <div className="page-content pointer-events: auto;">
+              <div className="page-content">
                 <div className="home">
                   <div className="intro-wrapper">
                     <div className="intro-text">
                       {/* título 1 */}
-                      <h3 className="intro-id opacity: 1; transform: none;">
+                      <h3 className="intro-id" style={fallStyle(0)}>
                         <Trans
                           i18nKey="home.hero.titleLine1"
                           components={{
@@ -254,7 +284,7 @@ export default function HomePage() {
                       </h3>
 
                       {/* título 2 */}
-                      <h3 className="intro-id opacity: 1; transform: none;">
+                      <h3 className="intro-id" style={fallStyle(1)}>
                         <Trans
                           i18nKey="home.hero.titleLine2"
                           components={{
@@ -267,10 +297,10 @@ export default function HomePage() {
 
                       {/* roles */}
                       <div className="intro-roles">
-                        <p className="intro-role opacity: 1; transform: none;">
+                        <p className="intro-role" style={fallStyle(2)}>
                           {t("home.hero.role1")}
                         </p>
-                        <p className="intro-role opacity: 1; transform: none;">
+                        <p className="intro-role" style={fallStyle(3)}>
                           {t("home.hero.role2")}
                         </p>
                       </div>
@@ -278,7 +308,7 @@ export default function HomePage() {
                       {/* CTAs */}
                       <div className="intro-links">
                         <ul>
-                          <li className="opacity: 1">
+                          <li style={fallStyle(4)}>
                             <div className="link-wrapper">
                               <div className="link">
                                 <a href="/work">
@@ -287,10 +317,15 @@ export default function HomePage() {
                                   </span>
                                 </a>
                               </div>
-                              <div className="link-underline transform: translateX(-101%) translateZ(0px);" />
+                              <div
+                                className="link-underline"
+                                style={{
+                                  transform: "translateX(-101%) translateZ(0)",
+                                }}
+                              />
                             </div>
                           </li>
-                          <li className="opacity: 1">
+                          <li style={fallStyle(5)}>
                             <div className="link-wrapper">
                               <div className="link">
                                 <a href="/about">

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -9,14 +9,17 @@ import {
   type CSSProperties,
 } from "react";
 
+import {
+  FALL_ITEM_TRANSITION_DURATION,
+  FALL_ITEM_STAGGER_DELAY,
+  getFallItemStyle,
+} from "./fallAnimation";
+
 type MenuProps = {
   isOpen: boolean;
   onClose: () => void;
   id?: string;
 };
-
-const ITEM_TRANSITION_DURATION = 400;
-const ITEM_STAGGER_DELAY = 60;
 
 export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }: MenuProps) {
   // itens principais â€“ mesmos rÃ³tulos / rotas da referÃªncia
@@ -55,8 +58,8 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
     }
 
     const totalDelay =
-      ITEM_TRANSITION_DURATION +
-      Math.max(totalItems - 1, 0) * ITEM_STAGGER_DELAY;
+      FALL_ITEM_TRANSITION_DURATION +
+      Math.max(totalItems - 1, 0) * FALL_ITEM_STAGGER_DELAY;
 
     hideTimeoutRef.current = window.setTimeout(() => {
       setIsVisible(false);
@@ -83,20 +86,8 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
   }, [isOpen, onClose]);
 
   // animaÃ§Ã£o de entrada 1:1 com a referÃªncia: translateY(-100px) -> 0
-  const itemStyle = (i: number): CSSProperties => {
-    const delay = isOpen
-      ? i * ITEM_STAGGER_DELAY
-      : (totalItems - 1 - i) * ITEM_STAGGER_DELAY;
-
-    return {
-      transform: isOpen
-        ? "translateY(0px) translateZ(0px)"
-        : "translateY(-100px) translateZ(0px)",
-      opacity: isOpen ? 1 : 0,
-      transition: `transform ${ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1), opacity ${ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1)`,
-      transitionDelay: `${delay}ms`,
-    };
-  };
+  const itemStyle = (i: number): CSSProperties =>
+    getFallItemStyle(isOpen, i, totalItems);
 
   return (
     // estrutura e classes iguais Ã  referÃªncia
@@ -107,7 +98,7 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
         opacity: isOpen ? 1 : 0,
         visibility: isOpen || isVisible ? "visible" : "hidden",
         pointerEvents: isOpen ? "auto" : "none",
-        transition: `opacity ${ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1)`,
+        transition: `opacity ${FALL_ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1)`,
       }}
       role="dialog"
       aria-modal="true"

--- a/components/fallAnimation.ts
+++ b/components/fallAnimation.ts
@@ -1,0 +1,34 @@
+import type { CSSProperties } from "react";
+
+export const FALL_ITEM_TRANSITION_DURATION = 400;
+export const FALL_ITEM_STAGGER_DELAY = 60;
+
+const TRANSITION = `transform ${FALL_ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1), opacity ${FALL_ITEM_TRANSITION_DURATION}ms cubic-bezier(.22,.61,.36,1)`;
+
+export function getFallItemStyle(
+  isActive: boolean,
+  index: number,
+  total: number,
+  options?: { disable?: boolean },
+): CSSProperties {
+  if (options?.disable) {
+    return {
+      opacity: 1,
+      transform: "none",
+      transition: "none",
+    };
+  }
+
+  const delay = isActive
+    ? index * FALL_ITEM_STAGGER_DELAY
+    : (total - 1 - index) * FALL_ITEM_STAGGER_DELAY;
+
+  return {
+    opacity: isActive ? 1 : 0,
+    transform: isActive
+      ? "translateY(0px) translateZ(0px)"
+      : "translateY(-100px) translateZ(0px)",
+    transition: TRANSITION,
+    transitionDelay: `${delay}ms`,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared fall animation helper that mirrors the menu entrance/exit timing
- swap the preloader content to use the menu-style fall animation and skip the global animator
- apply the same fall animation to the home hero elements and clean up previous placeholder animation styles

## Testing
- npm run lint *(fails: prompts for initial ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b64a3008832fb25b96753058935a