### PR TITLE
Add minimum preload duration and sync home fall animation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,8 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { useReducedMotion } from "framer-motion";
 import { getFallItemStyle } from "@/components/fallAnimation";
 
+const APP_SHELL_REVEAL_EVENT = "app-shell:reveal";
+
 import {
   HERO_LINE_ONE_MONOGRAM,
   HERO_LINE_TWO_MONOGRAM,
@@ -238,14 +240,28 @@ export default function HomePage() {
   useEffect(() => {
     if (disableFallAnimation) {
       setIsFallActive(true);
-      return;
+      return undefined;
     }
 
-    const frame = requestAnimationFrame(() => {
-      setIsFallActive(true);
-    });
+    if (typeof window === "undefined") {
+      return undefined;
+    }
 
-    return () => cancelAnimationFrame(frame);
+    const activateFall = () => {
+      setIsFallActive(true);
+      window.removeEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+    };
+
+    if (document.body?.dataset.preloading === "false") {
+      activateFall();
+      return undefined;
+    }
+
+    window.addEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+
+    return () => {
+      window.removeEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+    };
   }, [disableFallAnimation]);
 
   const totalFallItems = 6;

--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -22,7 +22,7 @@ type PreloaderProps = {
 
 const STATIC_PREVIEW_STYLES = "h-48 w-48 rounded-full bg-fg/10";
 const INITIAL_PROGRESS = 12;
-const MIN_VISIBLE_TIME = 900;
+const MIN_VISIBLE_TIME = 5000;
 const READY_EXIT_BUFFER = 450;
 
 export default function Preloader({ onComplete }: PreloaderProps) {


### PR DESCRIPTION
## Summary
- extend the preloader visibility window to at least five seconds so content loads behind the curtain
- wait for the app-shell reveal event before triggering the Home page fall animation, keeping it in sync with the menu animation

## Testing
- not run (interactive ESLint prompt blocks `npm run lint`)

------
https://chatgpt.com/codex/tasks/task_e_68e2bc4de914832fb3a6bc5eee4b2a72