### PR TITLE
Fade home content when menu opens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1270,7 +1270,9 @@ footer .footer-wrapper .footer-right {
 .home {
     width: 100%;
     height: inherit;
-    justify-content: space-around
+    justify-content: space-around;
+    opacity: 1;
+    transition: opacity .4s ease
 }
 
 .home,.home .intro-wrapper {
@@ -1393,6 +1395,11 @@ body.dark .home .intro-wrapper .intro-text .intro-id .name {
 
 body.dark .home .intro-wrapper .intro-text .intro-id .wave-wrapper .wave {
     background-image: url(/wave.svg)
+}
+
+body[data-menu-open="true"] .home {
+    opacity: 0;
+    pointer-events: none
 }
 
 .about {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -20,6 +20,22 @@ export default function Navbar() {
   const animTimerRef = useRef<number | undefined>(undefined);
   const pathname = usePathname();
   useEffect(() => setIsOpen(false), [pathname]);
+  useEffect(() => {
+    const body = document.body;
+    if (!body) {
+      return;
+    }
+
+    if (isOpen) {
+      body.dataset.menuOpen = "true";
+    } else {
+      delete body.dataset.menuOpen;
+    }
+
+    return () => {
+      delete body.dataset.menuOpen;
+    };
+  }, [isOpen]);
   const { t } = useTranslation("common");
   const prefersReducedMotion = useReducedMotion();
   const disableFallAnimation = Boolean(prefersReducedMotion);


### PR DESCRIPTION
## Summary
- track the menu open state on the body element so pages can react to it
- fade the home section by lowering its opacity whenever the overlay menu is open

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f546329c832fa527e05b356384f9