### PR TITLE
Define dedicated menu overlay monogram variant

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,14 +10,34 @@ import { useTranslation } from "react-i18next";
 import "../app/i18n/config";
 import { useReducedMotion } from "framer-motion";
 import { getFallItemStyle } from "./fallAnimation";
+import {
+  MENU_OVERLAY_MONOGRAM,
+  createResponsiveHeroVariantState,
+  createVariantState,
+  type PointerDriver,
+  type PointerTarget,
+  type VariantState,
+} from "@/components/three/types";
 
 const APP_SHELL_REVEAL_EVENT = "app-shell:reveal";
+const MENU_MOBILE_BREAKPOINT = 990;
+
+type StoredSceneState = {
+  variant: VariantState;
+  parallax: boolean;
+  hovered: boolean;
+  cursorBoost: number;
+  pointerDriver: PointerDriver;
+  manualPointer: PointerTarget;
+};
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [hoverHold, setHoverHold] = useState(false);
   const animTimerRef = useRef<number | undefined>(undefined);
+  const storedSceneStateRef = useRef<StoredSceneState | null>(null);
+  const [menuSceneVersion, setMenuSceneVersion] = useState(0);
   const pathname = usePathname();
   useEffect(() => setIsOpen(false), [pathname]);
   useEffect(() => {
@@ -36,6 +56,79 @@ export default function Navbar() {
       delete body.dataset.menuOpen;
     };
   }, [isOpen]);
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const app = window.__THREE_APP__;
+    if (!app) {
+      const frame = window.requestAnimationFrame(() => {
+        setMenuSceneVersion((value) => value + 1);
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frame);
+      };
+    }
+
+    const computeMenuVariant = () =>
+      createResponsiveHeroVariantState(
+        MENU_OVERLAY_MONOGRAM,
+        window.innerWidth,
+        window.innerHeight,
+        MENU_MOBILE_BREAKPOINT,
+        MENU_MOBILE_BREAKPOINT,
+      );
+
+    const applyMenuVariant = () => {
+      app.setState({ variant: computeMenuVariant() });
+    };
+
+    const snapshot = app.bundle.getState();
+    storedSceneStateRef.current = {
+      variant: createVariantState(snapshot.variant),
+      parallax: snapshot.parallax,
+      hovered: snapshot.hovered,
+      cursorBoost: snapshot.cursorBoost,
+      pointerDriver: snapshot.pointerDriver,
+      manualPointer: { ...snapshot.manualPointer },
+    };
+
+    const initialMenuVariant = computeMenuVariant();
+
+    app.setState({
+      parallax: false,
+      hovered: false,
+      cursorBoost: 0,
+      pointerDriver: "manual",
+      manualPointer: { x: 0, y: 0 },
+      variant: initialMenuVariant,
+    });
+
+    window.addEventListener("resize", applyMenuVariant);
+
+    return () => {
+      window.removeEventListener("resize", applyMenuVariant);
+
+      const stored = storedSceneStateRef.current;
+      if (stored) {
+        app.setState({
+          parallax: stored.parallax,
+          hovered: stored.hovered,
+          cursorBoost: stored.cursorBoost,
+          pointerDriver: stored.pointerDriver,
+          manualPointer: { ...stored.manualPointer },
+          variant: createVariantState(stored.variant),
+        });
+        storedSceneStateRef.current = null;
+      }
+    };
+  }, [isOpen, menuSceneVersion]);
   const { t } = useTranslation("common");
   const prefersReducedMotion = useReducedMotion();
   const disableFallAnimation = Boolean(prefersReducedMotion);

--- a/components/three/types.ts
+++ b/components/three/types.ts
@@ -95,8 +95,42 @@ const createSecondaryMonogramVariant = (): VariantState => ({
   },
 });
 
+const createMenuMonogramVariant = (): VariantState => ({
+  torusSpringAzure: {
+    position: [-2.05, 0.08, -1.1],
+    rotation: [Math.PI / 2, Math.PI * -1.7, 0],
+    scale: [0.2, 0.2, 0.2],
+  },
+  waveSpringLime: {
+    position: [-1.45, -0.12, -2.05],
+    rotation: [0, Math.PI, Math.PI / 1.9],
+    scale: [0.16, 0.16, 0.16],
+  },
+  semiLimeFlamingo: {
+    position: [-2.7, -0.15, -0.5],
+    rotation: [Math.PI / 2, Math.PI * -0.35, 0],
+    scale: [0.15, 0.15, 0.15],
+  },
+  torusFlamingoLime: {
+    position: [-1.75, -0.3, -0.45],
+    rotation: [Math.PI / 2, Math.PI * -1.2, 0],
+    scale: [0.18, 0.18, 0.18],
+  },
+  semiFlamingoAzure: {
+    position: [-2.55, 0.05, 0.05],
+    rotation: [Math.PI / 2, Math.PI * -1.45, 0],
+    scale: [0.22, 0.22, 0.22],
+  },
+  sphereFlamingoSpring: {
+    position: [-1.25, -0.48, 0.35],
+    rotation: [0, 0, 0],
+    scale: 0.16,
+  },
+});
+
 export const HERO_LINE_ONE_MONOGRAM = createPrimaryMonogramVariant();
 export const HERO_LINE_TWO_MONOGRAM = createSecondaryMonogramVariant();
+export const MENU_OVERLAY_MONOGRAM = createMenuMonogramVariant();
 
 
 //Posição inicial


### PR DESCRIPTION
## Summary
- add a dedicated menu overlay monogram variant distinct from the hero setup
- wire the navbar menu overlay to use the new variant when computing responsive positioning

## Testing
- npm run lint *(fails: command prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3285a5f84832f89ce1098151bfc32