### PR TITLE
Adjust dark theme shape color

### DIFF
--- a/components/three/addShapes.ts
+++ b/components/three/addShapes.ts
@@ -431,8 +431,13 @@ export async function addDuartoisSignatureShapes(
         mesh.material = material;
       }
 
-      material.vertexColors = true;
-      material.color.set(isDark ? "#1b1d28" : "#f6f7ff");
+      if (isDark) {
+        material.vertexColors = false;
+        material.color.set("#4a4d57");
+      } else {
+        material.vertexColors = true;
+        material.color.set("#f6f7ff");
+      }
       material.opacity = 1;
       material.transparent = false;
       material.metalness = isDark ? 0.008 : 0.005;


### PR DESCRIPTION
## Summary
- update the Three.js shape material handling to disable vertex gradients in dark mode
- apply a uniform lead gray color to the shapes when the dark theme is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e34cc62550832fa08c210c18651f91