### PR TITLE
Refine localized navigation and rebuild section pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Navbar from "../../components/Navbar";
 import Link from "next/link";
-import { Trans, useTranslation } from "react-i18next";
 import Image from "next/image";
+import { Trans, useTranslation } from "react-i18next";
 import "../i18n/config";
 
 import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
@@ -14,7 +13,92 @@ export default function AboutPage() {
   useThreeSceneSetup("about");
 
   return (
-    <>
-    </>
+    <main className="relative z-10 flex min-h-screen w-full flex-col">
+      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center gap-16 px-6 py-24">
+        <header
+          className="page-animate space-y-4 text-center sm:text-left"
+          data-hero-index={0}
+        >
+          <span className="text-xs font-medium uppercase tracking-[0.4em] text-fg/60">
+            {t("about.kicker")}
+          </span>
+          <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+            {t("about.title")}
+          </h1>
+          <p className="text-base text-fg/70 sm:text-lg">
+            {t("about.subtitle")}
+          </p>
+        </header>
+
+        <section
+          className="page-animate grid w-full gap-12 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] md:items-center"
+          data-hero-index={1}
+        >
+          <div className="space-y-6 text-center text-base leading-relaxed text-fg/70 sm:text-lg md:text-left">
+            <p>{t("about.paragraphs.first")}</p>
+            <p>{t("about.paragraphs.second")}</p>
+            <p>
+              <Trans
+                i18nKey="about.paragraphs.third"
+                components={{
+                  github: (
+                    <Link
+                      href="https://github.com/duartois"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-semibold text-fg hover:text-fg/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg"
+                    />
+                  ),
+                }}
+              />
+            </p>
+
+            <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-start">
+              <a
+                href="/files/resume.pdf"
+                className="w-full rounded-full border border-fg/20 bg-fg px-8 py-3 text-center text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
+              >
+                {t("about.cta.resume")}
+              </a>
+              <Link
+                href="/contact"
+                className="w-full rounded-full border border-fg/20 px-8 py-3 text-center text-sm font-semibold uppercase tracking-[0.3em] text-fg transition hover:border-fg/40 hover:bg-bg/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
+              >
+                {t("about.cta.contact")}
+              </Link>
+            </div>
+          </div>
+
+          <div className="relative flex w-full justify-center md:justify-end">
+            <div className="relative w-full max-w-sm">
+              <div
+                aria-hidden
+                className="absolute -inset-6 rounded-[3rem] border border-fg/10 bg-bg/60 blur-2xl"
+              />
+              <div className="relative overflow-hidden rounded-[3rem] border border-fg/15 bg-bg/80 p-6 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.65)] backdrop-blur">
+                <Image
+                  src="/about-portrait.svg"
+                  alt={t("about.portraitAlt")}
+                  width={640}
+                  height={640}
+                  className="h-auto w-full"
+                  priority
+                />
+                <div className="mt-6 flex items-center justify-between gap-4 text-xs uppercase tracking-[0.4em] text-fg/60">
+                  <Image
+                    src="/wave.svg"
+                    alt={t("about.badgeAlt")}
+                    width={72}
+                    height={72}
+                    className="h-16 w-16"
+                  />
+                  <span>{t("about.kicker")}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
-import Navbar from "../../components/Navbar";
+import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -13,6 +12,20 @@ export default function ContactPage() {
 
   useThreeSceneSetup("contact");
 
+  useEffect(() => {
+    if (status !== "submitted") {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setStatus("idle");
+    }, 6000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [status]);
+
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const form = event.currentTarget;
@@ -21,77 +34,69 @@ export default function ContactPage() {
   };
 
   return (
-    <>
-      <Navbar />
-      <main className="relative z-10 flex min-h-screen w-full flex-col">
-        <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left bg-bg/70">
-          <div className="page-animate space-y-4" data-hero-index={0}>
-            <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
-              {t("contact.title")}
-            </h1>
-            <p
-              className="text-base text-fg/70 sm:text-lg"
-            >
-              {t("contact.subtitle")}
-            </p>
-          </div>
-          <form
-            onSubmit={handleSubmit}
-            className="page-animate w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)]"
-            data-hero-index={1}
-          >
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span>{t("contact.form.nameLabel")}</span>
-                <input
-                  type="text"
-                  name="name"
-                  required
-                  className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
-                  placeholder={t("contact.form.namePlaceholder")}
-                />
-              </label>
-              <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-                <span>{t("contact.form.emailLabel")}</span>
-                <input
-                  type="email"
-                  name="email"
-                  required
-                  className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
-                  placeholder={t("contact.form.emailPlaceholder")}
-                />
-              </label>
-            </div>
+    <main className="relative z-10 flex min-h-screen w-full flex-col">
+      <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left">
+        <div
+          className="page-animate space-y-4 text-center sm:text-left"
+          data-hero-index={0}
+        >
+          <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+            {t("contact.title")}
+          </h1>
+          <p className="text-base text-fg/70 sm:text-lg">
+            {t("contact.subtitle")}
+          </p>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="page-animate w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)] backdrop-blur"
+          data-hero-index={1}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
-              <span>{t("contact.form.messageLabel")}</span>
-              <textarea
-                name="message"
+              <span>{t("contact.form.nameLabel")}</span>
+              <input
+                type="text"
+                name="name"
                 required
-                rows={5}
-                className="rounded-3xl border border-fg/20 bg-transparent px-4 py-4 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
-                placeholder={t("contact.form.messagePlaceholder")}
+                className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+                placeholder={t("contact.form.namePlaceholder")}
               />
             </label>
-            <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
-              <button
-                type="submit"
-                className="w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
-              >
-                {t("contact.form.submit")}
-              </button>
-              <div className="min-h-[1.5rem] text-sm text-fg/70" aria-live="polite">
-                {status === "submitted" ? (
-                  <span>
-                    {t("contact.form.success")}
-                  </span>
-                ) : (
-                  ""
-                )}
-              </div>
+            <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
+              <span>{t("contact.form.emailLabel")}</span>
+              <input
+                type="email"
+                name="email"
+                required
+                className="rounded-full border border-fg/20 bg-transparent px-4 py-3 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+                placeholder={t("contact.form.emailPlaceholder")}
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">
+            <span>{t("contact.form.messageLabel")}</span>
+            <textarea
+              name="message"
+              required
+              rows={5}
+              className="rounded-3xl border border-fg/20 bg-transparent px-4 py-4 text-base text-fg placeholder:text-fg/40 focus:border-fg/50 focus:outline-none focus:ring-2 focus:ring-fg/30"
+              placeholder={t("contact.form.messagePlaceholder")}
+            />
+          </label>
+          <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+            <button
+              type="submit"
+              className="w-full rounded-full bg-fg px-8 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-bg transition hover:bg-fg/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg sm:w-auto"
+            >
+              {t("contact.form.submit")}
+            </button>
+            <div className="min-h-[1.5rem] text-sm text-fg/70" aria-live="polite">
+              {status === "submitted" ? t("contact.form.success") : ""}
             </div>
-          </form>
-        </div>
-      </main>
-    </>
+          </div>
+        </form>
+      </div>
+    </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslation, Trans } from "react-i18next";
 import "./i18n/config";
 import { useThreeSceneSetup } from "./helpers/useThreeSceneSetup";
@@ -354,11 +355,11 @@ export default function HomePage() {
                           <li style={fallStyle(4)}>
                             <div className="link-wrapper">
                               <div className="link">
-                                <a href="/work">
+                                <Link href="/work">
                                   <span>
                                     {t("home.hero.ctaProjects")}
                                   </span>
-                                </a>
+                                </Link>
                               </div>
                               <div
                                 className="link-underline"
@@ -371,11 +372,11 @@ export default function HomePage() {
                           <li style={fallStyle(5)}>
                             <div className="link-wrapper">
                               <div className="link">
-                                <a href="/about">
+                                <Link href="/about">
                                   <span>
                                     {t("home.hero.ctaAbout")}
                                   </span>
-                                </a>
+                                </Link>
                               </div>
                               <div className="link-underline" />
                             </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import Navbar from "../../components/Navbar";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -18,6 +17,13 @@ type ProjectPreview = {
   showDescription?: boolean;
 };
 
+type ProjectCopy = {
+  title: string;
+  year: string;
+  description: string;
+  previewAlt: string;
+};
+
 const projectPreviews: Record<ProjectKey, ProjectPreview> = {
   aurora: {
     variantName: "home",
@@ -31,29 +37,175 @@ const projectPreviews: Record<ProjectKey, ProjectPreview> = {
   },
 };
 
+const previewGradients: Record<ProjectKey, string> = {
+  aurora:
+    "linear-gradient(135deg, rgba(153,185,255,0.65) 0%, rgba(255,179,194,0.55) 50%, rgba(120,255,209,0.65) 100%)",
+  mare:
+    "linear-gradient(135deg, rgba(120,255,209,0.6) 0%, rgba(153,185,255,0.55) 45%, rgba(48,113,147,0.65) 100%)",
+  spectrum:
+    "linear-gradient(135deg, rgba(255,179,194,0.6) 0%, rgba(153,185,255,0.55) 50%, rgba(240,255,166,0.65) 100%)",
+};
+
 export default function WorkPage() {
   const { t } = useTranslation("common");
-  const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
   const shouldReduceMotion = useReducedMotion();
-
-  const activePreview = projectPreviews[activeProject];
+  const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
 
   useThreeSceneSetup("work", { resetOnUnmount: true });
 
+  const projectCopy = useMemo(
+    () =>
+      projectOrder.reduce(
+        (copy, key) => {
+          copy[key] = t(`work.projects.${key}`, {
+            returnObjects: true,
+          }) as ProjectCopy;
+          return copy;
+        },
+        {} as Record<ProjectKey, ProjectCopy>,
+      ),
+    [t],
+  );
+
+  const activePreview = projectPreviews[activeProject];
+  const activeCopy = projectCopy[activeProject];
+
   useEffect(() => {
-    const preview = activePreview;
     window.__THREE_APP__?.setState({
-      variantName: preview.variantName,
+      variantName: activePreview.variantName,
       parallax: false,
       hovered: true,
       opacity: 0.3,
     });
-  }, [activePreview]);
+  }, [activePreview, activeProject]);
 
+  const transition = {
+    duration: 0.45,
+    ease: [0.22, 0.61, 0.36, 1] as [number, number, number, number],
+  };
 
   return (
-    <>
-      <Navbar />
-    </>
+    <main className="relative z-10 flex min-h-screen w-full flex-col">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24">
+        <header
+          className="page-animate space-y-4 text-center sm:text-left"
+          data-hero-index={0}
+        >
+          <span className="text-xs font-medium uppercase tracking-[0.4em] text-fg/60">
+            {t("work.previewHint")}
+          </span>
+          <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
+            {t("work.title")}
+          </h1>
+          <p className="text-base text-fg/70 sm:text-lg">
+            {t("work.subtitle")}
+          </p>
+        </header>
+
+        <section
+          className="page-animate grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]"
+          data-hero-index={1}
+        >
+          <ol className="grid gap-4">
+            {projectOrder.map((projectKey) => {
+              const copy = projectCopy[projectKey];
+              const isActive = projectKey === activeProject;
+
+              return (
+                <li key={projectKey}>
+                  <button
+                    type="button"
+                    aria-pressed={isActive}
+                    className={`group flex w-full items-center justify-between gap-4 rounded-3xl border px-6 py-5 text-left transition backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg ${
+                      isActive
+                        ? "border-transparent bg-fg text-bg shadow-[0_20px_50px_-30px_rgba(0,0,0,0.65)]"
+                        : "border-fg/15 bg-bg/70 text-fg/80 hover:border-fg/30 hover:bg-bg/85"
+                    }`}
+                    onClick={() => setActiveProject(projectKey)}
+                    onPointerEnter={() => {
+                      if (!isActive) {
+                        setActiveProject(projectKey);
+                      }
+                    }}
+                    onFocus={() => {
+                      if (!isActive) {
+                        setActiveProject(projectKey);
+                      }
+                    }}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span
+                        className={`text-xs font-semibold uppercase tracking-[0.35em] ${
+                          isActive ? "text-bg/70" : "text-fg/60"
+                        }`}
+                      >
+                        {copy.year}
+                      </span>
+                      <span
+                        className={`text-2xl font-semibold transition-colors ${
+                          isActive ? "text-bg" : "text-fg"
+                        }`}
+                      >
+                        {copy.title}
+                      </span>
+                    </div>
+                    <span
+                      aria-hidden
+                      className={`text-2xl transition-transform duration-300 ease-pleasant ${
+                        isActive ? "translate-x-1" : "translate-x-0 text-fg/40 group-hover:translate-x-1"
+                      }`}
+                    >
+                      ↗
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+
+          <div className="relative">
+            <div className="h-full rounded-3xl border border-fg/15 bg-bg/70 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.65)] backdrop-blur">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={activeProject}
+                  initial={
+                    shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }
+                  }
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -24 }}
+                  transition={transition}
+                  className="flex h-full flex-col gap-6"
+                >
+                  <div>
+                    <p className="text-sm font-medium uppercase tracking-[0.35em] text-fg/60">
+                      {activeCopy.year}
+                    </p>
+                    <h2 className="mt-2 text-3xl font-semibold text-fg">
+                      {activeCopy.title}
+                    </h2>
+                  </div>
+
+                  {(activePreview.showDescription ?? true) && (
+                    <p className="max-w-2xl text-base text-fg/70 sm:text-lg">
+                      {activeCopy.description}
+                    </p>
+                  )}
+
+                  <figure className="mt-auto overflow-hidden rounded-2xl border border-fg/10 bg-bg/80">
+                    <div
+                      className="aspect-[4/3] w-full"
+                      style={{ background: previewGradients[activeProject] }}
+                    />
+                    <figcaption className="visually-hidden">
+                      {activeCopy.previewAlt}
+                    </figcaption>
+                  </figure>
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
   );
 }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,29 +1,44 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import i18n from "@/app/i18n/config";
 
+type SupportedLanguage = "pt" | "en";
+
 export default function LanguageSwitcher() {
-  const [lang, setLang] = useState<"pt" | "en">("pt");
+  const { t } = useTranslation("common");
+  const [lang, setLang] = useState<SupportedLanguage>("pt");
+
   useEffect(() => {
-    setLang((i18n.language as any) || "pt");
-    const onChanged = (l: string) => setLang((l as any) || "pt");
+    setLang((i18n.language as SupportedLanguage) || "pt");
+    const onChanged = (language: string) =>
+      setLang((language as SupportedLanguage) || "pt");
+
     i18n.on("languageChanged", onChanged);
-    return () => i18n.off("languageChanged", onChanged);
+
+    return () => {
+      i18n.off("languageChanged", onChanged);
+    };
   }, []);
-  const target = lang === "en" ? "pt" : "en";
+
+  const target: SupportedLanguage = lang === "en" ? "pt" : "en";
+  const targetLabel = t(`languageSwitcher.labels.${target}`);
+  const switchLabel = t(`languageSwitcher.switchTo.${target}`);
+  const currentLabel = t(`languageSwitcher.current.${lang}`);
 
   return (
     <a
       href="#"
-      title={target.toUpperCase()}
-      aria-label={target === "en" ? "Switch to English" : "Mudar para Português"}
-      onClick={(e) => {
-        e.preventDefault();
+      title={targetLabel}
+      aria-label={switchLabel}
+      onClick={(event) => {
+        event.preventDefault();
         i18n.changeLanguage(target);
       }}
     >
-      {target.toUpperCase()}
+      <span aria-hidden>{targetLabel}</span>
+      <span className="visually-hidden">{currentLabel}</span>
     </a>
   );
 }

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -8,6 +8,9 @@ import {
   useState,
   type CSSProperties,
 } from "react";
+import { useTranslation } from "react-i18next";
+
+import "@/app/i18n/config";
 
 import {
   FALL_ITEM_TRANSITION_DURATION,
@@ -22,15 +25,16 @@ type MenuProps = {
 };
 
 export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }: MenuProps) {
-  // itens principais â€“ mesmos rÃ³tulos / rotas da referÃªncia
+  const { t } = useTranslation("common");
+
   const items = useMemo(
     () => [
-      { href: "/", label: "Home" },
-      { href: "/work", label: "Work" },
-      { href: "/about", label: "About" },
-      { href: "/contact", label: "Contact" },
+      { href: "/", label: t("navigation.home") },
+      { href: "/work", label: t("navigation.work") },
+      { href: "/about", label: t("navigation.about") },
+      { href: "/contact", label: t("navigation.contact") },
     ],
-    []
+    [t]
   );
 
   // redes sociais â€“ iguais Ã  referÃªncia

--- a/public/files/resume.pdf
+++ b/public/files/resume.pdf
@@ -1,0 +1,38 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 73 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Resume preview coming soon.) Tj
+72 680 Td
+(Reach out via the contact page for the full version.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000114 00000 n 
+0000000257 00000 n 
+0000000403 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+501
+%%EOF

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,23 @@
 {
   "languageSwitcher": {
-    "ariaLabel": "Language set to English"
+    "current": {
+      "en": "Language set to English",
+      "pt": "Language set to Portuguese"
+    },
+    "switchTo": {
+      "en": "Switch to English",
+      "pt": "Switch to Portuguese"
+    },
+    "labels": {
+      "en": "EN",
+      "pt": "PT"
+    }
+  },
+  "navigation": {
+    "home": "Home",
+    "work": "Work",
+    "about": "About",
+    "contact": "Contact"
   },
   "navbar": {
     "open": "Open navigation",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1,6 +1,23 @@
 {
   "languageSwitcher": {
-    "ariaLabel": "Idioma definido para inglês"
+    "current": {
+      "en": "Idioma definido para inglês",
+      "pt": "Idioma definido para português"
+    },
+    "switchTo": {
+      "en": "Mudar para inglês",
+      "pt": "Mudar para português"
+    },
+    "labels": {
+      "en": "EN",
+      "pt": "PT"
+    }
+  },
+  "navigation": {
+    "home": "Início",
+    "work": "Projetos",
+    "about": "Sobre",
+    "contact": "Contato"
   },
   "navbar": {
     "open": "Abrir navegação",


### PR DESCRIPTION
## Summary
- localize the navigation overlay and language switcher so menu labels translate alongside the rest of the UI
- rebuild the work, about, and contact pages inside the shared shell to keep the canvas background and single navbar while adding richer content
- update home hero links to use Next.js routing and add a downloadable resume placeholder referenced from the about page

## Testing
- npm run lint *(fails: command opens interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e3514a5d0c832f9eb218a84d4c20ae