### PR TITLE
Hide inner page content when menu opens

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,18 +6,27 @@ import { Trans, useTranslation } from "react-i18next";
 import "../i18n/config";
 
 import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
+import { useMenu } from "@/components/MenuContext";
+import { useMenuFallAnimation } from "@/components/useMenuFallAnimation";
 
 export default function AboutPage() {
   const { t } = useTranslation("common");
+  const { isOpen: isMenuOpen } = useMenu();
+  const fallStyle = useMenuFallAnimation(2);
 
   useThreeSceneSetup("about");
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">
-      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center gap-16 px-6 py-24">
+      <div
+        className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center gap-16 px-6 py-24"
+        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        aria-hidden={isMenuOpen}
+      >
         <header
           className="page-animate space-y-4 text-center sm:text-left"
           data-hero-index={0}
+          style={fallStyle(0)}
         >
           <span className="text-xs font-medium uppercase tracking-[0.4em] text-fg/60">
             {t("about.kicker")}
@@ -33,6 +42,7 @@ export default function AboutPage() {
         <section
           className="page-animate grid w-full gap-12 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] md:items-center"
           data-hero-index={1}
+          style={fallStyle(1)}
         >
           <div className="space-y-6 text-center text-base leading-relaxed text-fg/70 sm:text-lg md:text-left">
             <p>{t("about.paragraphs.first")}</p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -5,10 +5,14 @@ import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
 import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
+import { useMenu } from "@/components/MenuContext";
+import { useMenuFallAnimation } from "@/components/useMenuFallAnimation";
 
 export default function ContactPage() {
   const { t } = useTranslation("common");
   const [status, setStatus] = useState<"idle" | "submitted">("idle");
+  const { isOpen: isMenuOpen } = useMenu();
+  const fallStyle = useMenuFallAnimation(2);
 
   useThreeSceneSetup("contact");
 
@@ -35,10 +39,15 @@ export default function ContactPage() {
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">
-      <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left">
+      <div
+        className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left"
+        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        aria-hidden={isMenuOpen}
+      >
         <div
           className="page-animate space-y-4 text-center sm:text-left"
           data-hero-index={0}
+          style={fallStyle(0)}
         >
           <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
             {t("contact.title")}
@@ -51,6 +60,7 @@ export default function ContactPage() {
           onSubmit={handleSubmit}
           className="page-animate w-full space-y-4 rounded-3xl border border-fg/15 bg-bg/75 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.6)] backdrop-blur"
           data-hero-index={1}
+          style={fallStyle(1)}
         >
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="flex flex-col gap-2 text-left text-sm font-medium uppercase tracking-[0.3em] text-fg/70">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -7,6 +7,8 @@ import "../i18n/config";
 
 import { type VariantName } from "../../components/three/types";
 import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
+import { useMenu } from "@/components/MenuContext";
+import { useMenuFallAnimation } from "@/components/useMenuFallAnimation";
 
 const projectOrder = ["aurora", "mare", "spectrum"] as const;
 
@@ -50,6 +52,8 @@ export default function WorkPage() {
   const { t } = useTranslation("common");
   const shouldReduceMotion = useReducedMotion();
   const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
+  const { isOpen: isMenuOpen } = useMenu();
+  const fallStyle = useMenuFallAnimation(2);
 
   useThreeSceneSetup("work", { resetOnUnmount: true });
 
@@ -86,10 +90,15 @@ export default function WorkPage() {
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">
-      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24">
+      <div
+        className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24"
+        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        aria-hidden={isMenuOpen}
+      >
         <header
           className="page-animate space-y-4 text-center sm:text-left"
           data-hero-index={0}
+          style={fallStyle(0)}
         >
           <span className="text-xs font-medium uppercase tracking-[0.4em] text-fg/60">
             {t("work.previewHint")}
@@ -105,6 +114,7 @@ export default function WorkPage() {
         <section
           className="page-animate grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]"
           data-hero-index={1}
+          style={fallStyle(1)}
         >
           <ol className="grid gap-4">
             {projectOrder.map((projectKey) => {

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import Preloader from "./Preloader";
 import CanvasRoot from "./three/CanvasRoot";
+import { MenuProvider } from "./MenuContext";
 
 interface AppShellProps {
   children: ReactNode;
@@ -60,17 +61,19 @@ export default function AppShell({ children, navbar }: AppShellProps) {
   }, [isContentVisible]);
 
   return (
-    <div className="relative min-h-screen w-full overflow-hidden">
-      {!isReady && <Preloader onComplete={handleComplete} />}
-      <CanvasRoot isReady={isReady} />
-      <div
-        className={isContentVisible ? "" : "pointer-events-none"}
-        aria-hidden={!isContentVisible}
-        aria-busy={!isContentVisible}
-      >
-        {navbar}
-        {children}
+    <MenuProvider>
+      <div className="relative min-h-screen w-full overflow-hidden">
+        {!isReady && <Preloader onComplete={handleComplete} />}
+        <CanvasRoot isReady={isReady} />
+        <div
+          className={isContentVisible ? "" : "pointer-events-none"}
+          aria-hidden={!isContentVisible}
+          aria-busy={!isContentVisible}
+        >
+          {navbar}
+          {children}
+        </div>
       </div>
-    </div>
+    </MenuProvider>
   );
 }

--- a/components/MenuContext.tsx
+++ b/components/MenuContext.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
+
+export type MenuContextValue = {
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+};
+
+const MenuContext = createContext<MenuContextValue | undefined>(undefined);
+
+export function MenuProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => {
+    setIsOpen((previous) => !previous);
+  }, []);
+
+  const value = useMemo<MenuContextValue>(
+    () => ({ isOpen, setIsOpen, open, close, toggle }),
+    [close, isOpen, open, toggle],
+  );
+
+  return <MenuContext.Provider value={value}>{children}</MenuContext.Provider>;
+}
+
+export function useMenu() {
+  const context = useContext(MenuContext);
+
+  if (!context) {
+    throw new Error("useMenu must be used within a MenuProvider");
+  }
+
+  return context;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import "../app/i18n/config";
 import { useReducedMotion } from "framer-motion";
 import { getFallItemStyle } from "./fallAnimation";
+import { useMenu } from "./MenuContext";
 import {
   MENU_OVERLAY_MONOGRAM,
   createResponsiveHeroVariantState,
@@ -32,7 +33,7 @@ type StoredSceneState = {
 };
 
 export default function Navbar() {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, setIsOpen } = useMenu();
   const [isAnimating, setIsAnimating] = useState(false);
   const [hoverHold, setHoverHold] = useState(false);
   const animTimerRef = useRef<number | undefined>(undefined);

--- a/components/useMenuFallAnimation.ts
+++ b/components/useMenuFallAnimation.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+
+import { getFallItemStyle } from "./fallAnimation";
+import { useMenu } from "./MenuContext";
+
+const APP_SHELL_REVEAL_EVENT = "app-shell:reveal";
+
+export function useMenuFallAnimation(totalItems: number) {
+  const { isOpen } = useMenu();
+  const prefersReducedMotion = useReducedMotion();
+  const disableFallAnimation = Boolean(prefersReducedMotion);
+  const [isFallActive, setIsFallActive] = useState(disableFallAnimation);
+
+  useEffect(() => {
+    if (disableFallAnimation) {
+      setIsFallActive(true);
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const activateFall = () => {
+      setIsFallActive(true);
+      window.removeEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+    };
+
+    if (typeof document !== "undefined" && document.body?.dataset.preloading === "false") {
+      activateFall();
+      return;
+    }
+
+    window.addEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+
+    return () => {
+      window.removeEventListener(APP_SHELL_REVEAL_EVENT, activateFall);
+    };
+  }, [disableFallAnimation]);
+
+  return useCallback(
+    (index: number) =>
+      getFallItemStyle(isFallActive && !isOpen, index, totalItems, {
+        disable: disableFallAnimation,
+      }),
+    [disableFallAnimation, isFallActive, isOpen, totalItems],
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared menu context so the menu open state can be consumed across pages
- wrap the app shell with the provider and update the navbar to rely on the shared state
- animate and disable the work, about, and contact sections when the menu overlay is open using the fall animation helper

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e354e8cc24832f8b1cb42394ac41af