### PR TITLE
Hide page content when menu is open

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -20,7 +20,11 @@ export default function AboutPage() {
     <main className="relative z-10 flex min-h-screen w-full flex-col">
       <div
         className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center gap-16 px-6 py-24"
-        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        style={{
+          pointerEvents: isMenuOpen ? "none" : undefined,
+          opacity: isMenuOpen ? 0 : 1,
+          transition: "opacity 300ms ease",
+        }}
         aria-hidden={isMenuOpen}
       >
         <header

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -41,7 +41,11 @@ export default function ContactPage() {
     <main className="relative z-10 flex min-h-screen w-full flex-col">
       <div
         className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center gap-10 px-6 py-24 text-center sm:text-left"
-        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        style={{
+          pointerEvents: isMenuOpen ? "none" : undefined,
+          opacity: isMenuOpen ? 0 : 1,
+          transition: "opacity 300ms ease",
+        }}
         aria-hidden={isMenuOpen}
       >
         <div

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -92,7 +92,11 @@ export default function WorkPage() {
     <main className="relative z-10 flex min-h-screen w-full flex-col">
       <div
         className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24"
-        style={{ pointerEvents: isMenuOpen ? "none" : undefined }}
+        style={{
+          pointerEvents: isMenuOpen ? "none" : undefined,
+          opacity: isMenuOpen ? 0 : 1,
+          transition: "opacity 300ms ease",
+        }}
         aria-hidden={isMenuOpen}
       >
         <header


### PR DESCRIPTION
## Summary
- fade out the about, contact, and work page wrappers whenever the menu overlay is open to match the home behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c96f4878832fbb55a611da564af7