### PR TITLE
Revamp work projects layout

### DIFF
--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -10,47 +10,43 @@ import { useThreeSceneSetup } from "../helpers/useThreeSceneSetup";
 import { useMenu } from "@/components/MenuContext";
 import { useMenuFallAnimation } from "@/components/useMenuFallAnimation";
 
-const projectOrder = ["aurora", "mare", "spectrum"] as const;
+const projectOrder = [
+  "sharlee",
+  "actResponsable",
+  "duaLipa",
+  "cocolyze",
+  "lesIndecis",
+  "gameOfTheGoose",
+  "lequipeExplore",
+  "silhouette",
+  "portraits",
+] as const;
 
 type ProjectKey = (typeof projectOrder)[number];
 
 type ProjectPreview = {
   variantName: VariantName;
-  showDescription?: boolean;
 };
 
 type ProjectCopy = {
   title: string;
-  year: string;
-  description: string;
-  previewAlt: string;
+  category: string;
+  href: string;
+  cover: string;
+  coverAlt: string;
+  coverPlaceholder: string;
 };
 
-const projectPreviews: Record<ProjectKey, ProjectPreview> = {
-  aurora: {
-    variantName: "home",
+const projectPreviews: Record<ProjectKey, ProjectPreview> = projectOrder.reduce(
+  (previews, key) => {
+    previews[key] = { variantName: "work" };
+    return previews;
   },
-  mare: {
-    variantName: "about",
-    showDescription: true,
-  },
-  spectrum: {
-    variantName: "work",
-  },
-};
-
-const previewGradients: Record<ProjectKey, string> = {
-  aurora:
-    "linear-gradient(135deg, rgba(153,185,255,0.65) 0%, rgba(255,179,194,0.55) 50%, rgba(120,255,209,0.65) 100%)",
-  mare:
-    "linear-gradient(135deg, rgba(120,255,209,0.6) 0%, rgba(153,185,255,0.55) 45%, rgba(48,113,147,0.65) 100%)",
-  spectrum:
-    "linear-gradient(135deg, rgba(255,179,194,0.6) 0%, rgba(153,185,255,0.55) 50%, rgba(240,255,166,0.65) 100%)",
-};
+  {} as Record<ProjectKey, ProjectPreview>,
+);
 
 export default function WorkPage() {
   const { t } = useTranslation("common");
-  const shouldReduceMotion = useReducedMotion();
   const [activeProject, setActiveProject] = useState<ProjectKey>(projectOrder[0]);
   const { isOpen: isMenuOpen } = useMenu();
   const fallStyle = useMenuFallAnimation(2);
@@ -81,17 +77,12 @@ export default function WorkPage() {
       hovered: true,
       opacity: 0.3,
     });
-  }, [activePreview, activeProject]);
-
-  const transition = {
-    duration: 0.45,
-    ease: [0.22, 0.61, 0.36, 1] as [number, number, number, number],
-  };
+  }, [activePreview]);
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">
-      <div
-        className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-16 px-6 py-24"
+      <section
+        className="projects"
         style={{
           pointerEvents: isMenuOpen ? "none" : undefined,
           opacity: isMenuOpen ? 0 : 1,
@@ -99,127 +90,98 @@ export default function WorkPage() {
         }}
         aria-hidden={isMenuOpen}
       >
-        <header
-          className="page-animate space-y-4 text-center sm:text-left"
-          data-hero-index={0}
-          style={fallStyle(0)}
-        >
-          <span className="text-xs font-medium uppercase tracking-[0.4em] text-fg/60">
-            {t("work.previewHint")}
-          </span>
-          <h1 className="text-4xl font-semibold text-fg sm:text-5xl">
-            {t("work.title")}
-          </h1>
-          <p className="text-base text-fg/70 sm:text-lg">
-            {t("work.subtitle")}
-          </p>
-        </header>
-
-        <section
-          className="page-animate grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]"
-          data-hero-index={1}
-          style={fallStyle(1)}
-        >
-          <ol className="grid gap-4">
+        <div className="projects-left" style={fallStyle(0)}>
+          <div
+            className="projects-left-inside"
+            style={{ borderRadius: "0 48px 0 0", opacity: 1 }}
+          >
             {projectOrder.map((projectKey) => {
               const copy = projectCopy[projectKey];
               const isActive = projectKey === activeProject;
 
               return (
-                <li key={projectKey}>
-                  <button
-                    type="button"
-                    aria-pressed={isActive}
-                    className={`group flex w-full items-center justify-between gap-4 rounded-3xl border px-6 py-5 text-left transition backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg ${
-                      isActive
-                        ? "border-transparent bg-fg text-bg shadow-[0_20px_50px_-30px_rgba(0,0,0,0.65)]"
-                        : "border-fg/15 bg-bg/70 text-fg/80 hover:border-fg/30 hover:bg-bg/85"
-                    }`}
-                    onClick={() => setActiveProject(projectKey)}
-                    onPointerEnter={() => {
-                      if (!isActive) {
-                        setActiveProject(projectKey);
-                      }
-                    }}
-                    onFocus={() => {
-                      if (!isActive) {
-                        setActiveProject(projectKey);
-                      }
+                <div
+                  key={projectKey}
+                  className="projects-image-wrapper"
+                  style={{
+                    opacity: isActive ? 1 : 0,
+                    transition: "opacity 400ms ease",
+                  }}
+                >
+                  <div
+                    className="projects-image-scale"
+                    style={{
+                      transform: "none",
+                      transition: "transform 600ms ease",
                     }}
                   >
-                    <div className="flex flex-col gap-1">
-                      <span
-                        className={`text-xs font-semibold uppercase tracking-[0.35em] ${
-                          isActive ? "text-bg/70" : "text-fg/60"
-                        }`}
-                      >
-                        {copy.year}
-                      </span>
-                      <span
-                        className={`text-2xl font-semibold transition-colors ${
-                          isActive ? "text-bg" : "text-fg"
-                        }`}
-                      >
+                    <img
+                      alt={copy.coverAlt}
+                      src={copy.cover}
+                      className="projects-image"
+                      style={{
+                        backgroundColor: copy.coverPlaceholder,
+                        color: "transparent",
+                      }}
+                      loading={isActive ? "eager" : "lazy"}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="projects-right" style={fallStyle(1)}>
+          <div>
+            <div className="page-head">
+              <h2 className="page-title">{t("navigation.work")}</h2>
+              <h5 className="elements-number">{projectOrder.length}</h5>
+            </div>
+            <hr className="head-separator" />
+          </div>
+
+          <ul>
+            {projectOrder.map((projectKey) => {
+              const copy = projectCopy[projectKey];
+              const isActive = projectKey === activeProject;
+
+              return (
+                <li key={projectKey} style={{ opacity: 1 }}>
+                  <Link
+                    href={copy.href}
+                    className="projects-row"
+                    onMouseEnter={() => setActiveProject(projectKey)}
+                    onFocus={() => setActiveProject(projectKey)}
+                  >
+                    <div className="projects-row-left">
+                      <div className="projects-selected-wrapper">
+                        <h4
+                          className="projects-selected"
+                          style={{
+                            transform: isActive
+                              ? "translateX(0) translateZ(0)"
+                              : "translateX(-100%) translateZ(0)",
+                            transition: "transform 300ms ease",
+                          }}
+                        >
+                          →
+                        </h4>
+                      </div>
+                      <h4 className="projects-title" style={{ transform: "none" }}>
                         {copy.title}
-                      </span>
+                      </h4>
                     </div>
-                    <span
-                      aria-hidden
-                      className={`text-2xl transition-transform duration-300 ease-pleasant ${
-                        isActive ? "translate-x-1" : "translate-x-0 text-fg/40 group-hover:translate-x-1"
-                      }`}
-                    >
-                      ↗
-                    </span>
-                  </button>
+                    <div className="projects-row-right">
+                      <p className="projects-category">{copy.category}</p>
+                    </div>
+                  </Link>
                 </li>
               );
             })}
-          </ol>
-
-          <div className="relative">
-            <div className="h-full rounded-3xl border border-fg/15 bg-bg/70 p-8 shadow-[0_20px_50px_-30px_rgba(0,0,0,0.65)] backdrop-blur">
-              <AnimatePresence mode="wait" initial={false}>
-                <motion.div
-                  key={activeProject}
-                  initial={
-                    shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }
-                  }
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -24 }}
-                  transition={transition}
-                  className="flex h-full flex-col gap-6"
-                >
-                  <div>
-                    <p className="text-sm font-medium uppercase tracking-[0.35em] text-fg/60">
-                      {activeCopy.year}
-                    </p>
-                    <h2 className="mt-2 text-3xl font-semibold text-fg">
-                      {activeCopy.title}
-                    </h2>
-                  </div>
-
-                  {(activePreview.showDescription ?? true) && (
-                    <p className="max-w-2xl text-base text-fg/70 sm:text-lg">
-                      {activeCopy.description}
-                    </p>
-                  )}
-
-                  <figure className="mt-auto overflow-hidden rounded-2xl border border-fg/10 bg-bg/80">
-                    <div
-                      className="aspect-[4/3] w-full"
-                      style={{ background: previewGradients[activeProject] }}
-                    />
-                    <figcaption className="visually-hidden">
-                      {activeCopy.previewAlt}
-                    </figcaption>
-                  </figure>
-                </motion.div>
-              </AnimatePresence>
-            </div>
-          </div>
-        </section>
-      </div>
+          </ul>
+        </div>
+      </section>
     </main>
   );
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -40,23 +40,77 @@
     "subtitle": "Hover or focus to reveal snapshots of the hybrid process between 3D, code, and art direction.",
     "previewHint": "Pick a project",
     "projects": {
-      "aurora": {
-        "title": "Aurora Chromatica",
-        "year": "2024",
-        "description": "Responsive installation translating live soundtracks into luminous landscapes for an immersive festival.",
-        "previewAlt": "Abstract visualization of the Aurora Chromatica project."
+      "sharlee": {
+        "title": "Sharlee",
+        "category": "Branding",
+        "href": "/work/sharlee",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rr38gep0kx08ur49lovevv",
+        "coverAlt": "Cover of the project Sharlee",
+        "coverPlaceholder": "rgb(91, 237, 199)"
       },
-      "mare": {
-        "title": "Atlantic Tide",
-        "year": "2023",
-        "description": "Audiovisual narrative merging tide data, poetry, and projection mapping along the Portuguese coastline.",
-        "previewAlt": "Concept poster for the Atlantic Tide project."
+      "actResponsable": {
+        "title": "ACT Responsable",
+        "category": "Web Development",
+        "href": "/work/act-responsable",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rq5glpo27o07ukwp1itrg2",
+        "coverAlt": "Cover of the project ACT Responsable",
+        "coverPlaceholder": "rgb(231, 163, 167)"
       },
-      "spectrum": {
-        "title": "Spectrum Pulse",
-        "year": "2022",
-        "description": "Modular identity for a generative music platform with dynamic motion and print guidelines.",
-        "previewAlt": "Dynamic interface of the Spectrum Pulse project."
+      "duaLipa": {
+        "title": "Dua Lipa",
+        "category": "Portrait",
+        "href": "/work/dua-lipa",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs841tpy7n07ur7jivicon",
+        "coverAlt": "Cover of the project Dua Lipa",
+        "coverPlaceholder": "rgb(248, 255, 129)"
+      },
+      "cocolyze": {
+        "title": "Cocolyze",
+        "category": "UX/UI Design",
+        "href": "/work/cocolyze",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rqa5voo2gj08urw6x6qk8w",
+        "coverAlt": "Cover of the project Cocolyze",
+        "coverPlaceholder": "rgb(137, 223, 214)"
+      },
+      "lesIndecis": {
+        "title": "Les Indécis",
+        "category": "Branding",
+        "href": "/work/les-indecis",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs8yutpyup07ursumcy3r7",
+        "coverAlt": "Cover of the project Les Indécis",
+        "coverPlaceholder": "rgb(119, 208, 206)"
+      },
+      "gameOfTheGoose": {
+        "title": "Game of the goose",
+        "category": "Game Design",
+        "href": "/work/game-of-the-goose",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs7m8kpxp907urgq9ovkoo",
+        "coverAlt": "Cover of the project Game of the Goose",
+        "coverPlaceholder": "rgb(173, 188, 186)"
+      },
+      "lequipeExplore": {
+        "title": "L’Équipe Explore",
+        "category": "Illustration",
+        "href": "/work/lequipe-explore",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rsa2f5qa8e08uroxavu02d",
+        "coverAlt": "Cover of the project L’Équipe Explore",
+        "coverPlaceholder": "rgb(233, 220, 97)"
+      },
+      "silhouette": {
+        "title": "Silhouette",
+        "category": "Portrait",
+        "href": "/work/silhouette",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rr3xtxop0u07urwqls6szn",
+        "coverAlt": "Cover of the project Silhouette",
+        "coverPlaceholder": "rgb(163, 167, 185)"
+      },
+      "portraits": {
+        "title": "Portraits",
+        "category": "Portrait",
+        "href": "/work/portraits",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rsajlmq0e807uru9k9h1xu",
+        "coverAlt": "Cover of the project Portraits",
+        "coverPlaceholder": "rgb(248, 212, 195)"
       }
     }
   },

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -40,23 +40,77 @@
     "subtitle": "Passe o cursor ou use o teclado para revelar snapshots do processo híbrido entre 3D, código e direção de arte.",
     "previewHint": "Escolha um projeto",
     "projects": {
-      "aurora": {
-        "title": "Aurora Chromatica",
-        "year": "2024",
-        "description": "Instalação responsiva que traduz trilhas sonoras em paisagens luminosas ao vivo para um festival imersivo.",
-        "previewAlt": "Visualização abstrata do projeto Aurora Chromatica."
+      "sharlee": {
+        "title": "Sharlee",
+        "category": "Branding",
+        "href": "/work/sharlee",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rr38gep0kx08ur49lovevv",
+        "coverAlt": "Capa do projeto Sharlee",
+        "coverPlaceholder": "rgb(91, 237, 199)"
       },
-      "mare": {
-        "title": "Maré Atlântica",
-        "year": "2023",
-        "description": "Narrativa audiovisual que combina dados de marés, poesia e projeções para ocupar a costa portuguesa.",
-        "previewAlt": "Poster conceitual do projeto Maré Atlântica."
+      "actResponsable": {
+        "title": "ACT Responsable",
+        "category": "Desenvolvimento Web",
+        "href": "/work/act-responsable",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rq5glpo27o07ukwp1itrg2",
+        "coverAlt": "Capa do projeto ACT Responsable",
+        "coverPlaceholder": "rgb(231, 163, 167)"
       },
-      "spectrum": {
-        "title": "Spectrum Pulse",
-        "year": "2022",
-        "description": "Identidade modular para uma plataforma de música generativa com diretrizes dinâmicas para motion e print.",
-        "previewAlt": "Interface dinâmica do projeto Spectrum Pulse."
+      "duaLipa": {
+        "title": "Dua Lipa",
+        "category": "Retrato",
+        "href": "/work/dua-lipa",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs841tpy7n07ur7jivicon",
+        "coverAlt": "Capa do projeto Dua Lipa",
+        "coverPlaceholder": "rgb(248, 255, 129)"
+      },
+      "cocolyze": {
+        "title": "Cocolyze",
+        "category": "Design UX/UI",
+        "href": "/work/cocolyze",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rqa5voo2gj08urw6x6qk8w",
+        "coverAlt": "Capa do projeto Cocolyze",
+        "coverPlaceholder": "rgb(137, 223, 214)"
+      },
+      "lesIndecis": {
+        "title": "Les Indécis",
+        "category": "Branding",
+        "href": "/work/les-indecis",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs8yutpyup07ursumcy3r7",
+        "coverAlt": "Capa do projeto Les Indécis",
+        "coverPlaceholder": "rgb(119, 208, 206)"
+      },
+      "gameOfTheGoose": {
+        "title": "Game of the goose",
+        "category": "Game Design",
+        "href": "/work/game-of-the-goose",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rs7m8kpxp907urgq9ovkoo",
+        "coverAlt": "Capa do projeto Game of the Goose",
+        "coverPlaceholder": "rgb(173, 188, 186)"
+      },
+      "lequipeExplore": {
+        "title": "L’Équipe Explore",
+        "category": "Ilustração",
+        "href": "/work/lequipe-explore",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rsa2f5qa8e08uroxavu02d",
+        "coverAlt": "Capa do projeto L’Équipe Explore",
+        "coverPlaceholder": "rgb(233, 220, 97)"
+      },
+      "silhouette": {
+        "title": "Silhouette",
+        "category": "Retrato",
+        "href": "/work/silhouette",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rr3xtxop0u07urwqls6szn",
+        "coverAlt": "Capa do projeto Silhouette",
+        "coverPlaceholder": "rgb(163, 167, 185)"
+      },
+      "portraits": {
+        "title": "Portraits",
+        "category": "Retrato",
+        "href": "/work/portraits",
+        "cover": "https://eu-central-1.graphassets.com/AIsBIpEzjT9776nQrClIuz/cm7rsajlmq0e807uru9k9h1xu",
+        "coverAlt": "Capa do projeto Portraits",
+        "coverPlaceholder": "rgb(248, 212, 195)"
       }
     }
   },


### PR DESCRIPTION
## Summary
- redesign the /work projects section to mirror the requested two-column gallery layout with image previews
- extend English and Portuguese locale data with the nine showcased projects and metadata for covers, links, and categories

## Testing
- npm run lint *(fails: prompts for eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d3ea81c0832fbf735be2bed2ea19