### PR TITLE
Fix menu overlay opacity on secondary pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import "../i18n/config";
 
@@ -15,6 +16,10 @@ export default function AboutPage() {
   const fallStyle = useMenuFallAnimation(2);
 
   useThreeSceneSetup("about");
+
+  useEffect(() => {
+    window.__THREE_APP__?.setState({ opacity: isMenuOpen ? 1 : 0.3 });
+  }, [isMenuOpen]);
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -17,6 +17,10 @@ export default function ContactPage() {
   useThreeSceneSetup("contact");
 
   useEffect(() => {
+    window.__THREE_APP__?.setState({ opacity: isMenuOpen ? 1 : 0.3 });
+  }, [isMenuOpen]);
+
+  useEffect(() => {
     if (status !== "submitted") {
       return;
     }

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -75,9 +75,9 @@ export default function WorkPage() {
       variantName: activePreview.variantName,
       parallax: false,
       hovered: true,
-      opacity: 0.3,
+      opacity: isMenuOpen ? 1 : 0.3,
     });
-  }, [activePreview]);
+  }, [activePreview, isMenuOpen]);
 
   return (
     <main className="relative z-10 flex min-h-screen w-full flex-col">


### PR DESCRIPTION
## Summary
- ensure the menu overlay resets the scene opacity to full intensity on the work, about, and contact pages while it is open
- keep each page's standard scene opacity once the menu closes

## Testing
- not run (npm run lint)

------
https://chatgpt.com/codex/tasks/task_e_68e66f26c9d0832f801b2dfd0f202546