### PR TITLE
Prefetch main sections during preload

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,6 +10,7 @@ import {
 import Preloader from "./Preloader";
 import CanvasRoot from "./three/CanvasRoot";
 import { MenuProvider } from "./MenuContext";
+import RoutePrefetcher from "./RoutePrefetcher";
 
 interface AppShellProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ interface AppShellProps {
 }
 
 const REVEAL_EVENT = "app-shell:reveal";
+const ROUTES_TO_PREFETCH = ["/work", "/about", "/contact"] as const;
 
 export default function AppShell({ children, navbar }: AppShellProps) {
   const [isReady, setIsReady] = useState(false);
@@ -65,6 +67,7 @@ export default function AppShell({ children, navbar }: AppShellProps) {
       <div className="relative min-h-screen w-full overflow-hidden">
         {!isReady && <Preloader onComplete={handleComplete} />}
         <CanvasRoot isReady={isReady} />
+        <RoutePrefetcher routes={ROUTES_TO_PREFETCH} />
         <div
           className={isContentVisible ? "" : "pointer-events-none"}
           aria-hidden={!isContentVisible}

--- a/components/RoutePrefetcher.tsx
+++ b/components/RoutePrefetcher.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+export type RoutePrefetcherProps = {
+  routes: readonly string[];
+};
+
+export default function RoutePrefetcher({ routes }: RoutePrefetcherProps) {
+  const router = useRouter();
+  const prefetchedRoutesRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    routes.forEach((route) => {
+      if (prefetchedRoutesRef.current.has(route)) {
+        return;
+      }
+
+      prefetchedRoutesRef.current.add(route);
+      void router.prefetch(route);
+    });
+  }, [router, routes]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a reusable RoutePrefetcher client component to trigger Next.js router prefetching
- hook the prefetcher into the AppShell so /work, /about, and /contact load during the preload phase

## Testing
- not run (next lint prompts for interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68e676ed7b4c832fbc4ba77f90e7e21e