### PR TITLE
Add bounce animation to project hover state

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,7 @@
     --border-radius: 48px;
     --border: 2px;
     --border-radius-content: 0;
+    --projects-arrow-offset: 1.5rem;
     
 }
 main {
@@ -1889,19 +1890,25 @@ body.dark .project-content-image {
 
 .projects-right ul .projects-row-left .projects-selected-wrapper {
     position: absolute;
-    overflow: hidden
+    overflow: hidden;
+    width: var(--projects-arrow-offset);
+    display: flex;
+    align-items: center;
+    justify-content: center
 }
 
 .projects-right ul .projects-row-left .projects-selected-wrapper .projects-selected {
     padding-right: 12px;
-    position: relative
+    position: relative;
+    transition: transform 450ms cubic-bezier(.34,1.56,.64,1)
 }
 
 .projects-right ul .projects-row-left .projects-title {
     margin-right: var(--left-right-internal-margin);
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden
+    overflow: hidden;
+    transition: transform 450ms cubic-bezier(.34,1.56,.64,1)
 }
 
 .projects-right ul .projects-row-left .projects-is-new {

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -162,13 +162,21 @@ export default function WorkPage() {
                             transform: isActive
                               ? "translateX(0) translateZ(0)"
                               : "translateX(-100%) translateZ(0)",
-                            transition: "transform 300ms ease",
+                            transition:
+                              "transform 450ms cubic-bezier(0.34, 1.56, 0.64, 1)",
                           }}
                         >
                           →
                         </h4>
                       </div>
-                      <h4 className="projects-title" style={{ transform: "none" }}>
+                      <h4
+                        className="projects-title"
+                        style={{
+                          transform: isActive
+                            ? "translateX(var(--projects-arrow-offset))"
+                            : "translateX(0)",
+                        }}
+                      >
                         {copy.title}
                       </h4>
                     </div>


### PR DESCRIPTION
## Summary
- add a shared offset for the project arrow so titles slide alongside the indicator
- apply bounce easing transitions to the arrow and title hover animations for a more dynamic reveal

## Testing
- ⚠️ `npm run lint` *(blocked by interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e683a44d60832f8fdba4af2231ee9e