### PR TITLE
Allow Work page scrolling on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,30 @@ main {
     overflow: hidden;
     width: 100%
 }
+.body-scroll-control {
+    overflow-y: hidden
+}
+
+.app-shell {
+    overflow: hidden
+}
+
+@media(max-width: 56.24em) {
+    .body-scroll-control {
+        overflow-x: hidden;
+        overflow-y: auto
+    }
+
+    .app-shell {
+        overflow-x: hidden;
+        overflow-y: auto
+    }
+
+    main.work-page {
+        overflow-x: hidden;
+        overflow-y: auto
+    }
+}
 .cursor,
 .cursor-dot {
     position: fixed;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body
         data-preloading="true"
         className={classNames(
-          "bg-bg text-fg antialiased selection:bg-white/20 dark:selection:bg-white/10 overflow-y-hidden",
+          "bg-bg text-fg antialiased selection:bg-white/20 dark:selection:bg-white/10",
+          "body-scroll-control",
         )}
       >
         <ThemeProvider>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -80,7 +80,7 @@ export default function WorkPage() {
   }, [activePreview, isMenuOpen]);
 
   return (
-    <main className="relative z-10 flex min-h-screen w-full flex-col">
+    <main className="work-page relative z-10 flex min-h-screen w-full flex-col">
       <section
         className="projects"
         style={{

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -64,7 +64,7 @@ export default function AppShell({ children, navbar }: AppShellProps) {
 
   return (
     <MenuProvider>
-      <div className="relative min-h-screen w-full overflow-hidden">
+      <div className="app-shell relative min-h-screen w-full">
         {!isReady && <Preloader onComplete={handleComplete} />}
         <CanvasRoot isReady={isReady} />
         <RoutePrefetcher routes={ROUTES_TO_PREFETCH} />


### PR DESCRIPTION
## Summary
- add responsive overflow helpers for the body and app shell so small screens can scroll vertically
- mark the Work page main element for targeted mobile overflow overrides

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e6864b9268832fbfc509221b03bd9f