### PR TITLE
Fix menu social link hover underline animation

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -149,14 +149,7 @@ export default function Menu({ isOpen, onClose, id = "main-navigation-overlay" }
                           </a>
                         </div>
                         {/* underline comeÃ§a em -101% exatamente como na referÃªncia/CSS */}
-                        <div
-                          className="link-underline"
-                          style={{
-                            transform: isOpen
-                              ? "translateX(0) translateZ(0)"
-                              : "translateX(-101%) translateZ(0)",
-                          }}
-                        />
+                        <div className="link-underline" />
                       </div>
                     </div>
                   </li>


### PR DESCRIPTION
## Summary
- remove the manual transform toggle from the menu social link underline
- allow the Instagram and Behance links to reuse the shared hover animation styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e689a28dd0832fbe563858e9598477