### PR TITLE
Fix scene opacity on direct navigation reloads

### DIFF
--- a/app/helpers/useThreeSceneSetup.ts
+++ b/app/helpers/useThreeSceneSetup.ts
@@ -21,13 +21,21 @@ const applySceneState = (
   variantName: VariantName,
   { opacity, parallax, hovered }: Required<Omit<SceneOptions, "resetOnUnmount">>,
 ) => {
-  window.__THREE_APP__?.setState((previous) => ({
+  const app = window.__THREE_APP__;
+
+  if (!app) {
+    return false;
+  }
+
+  app.setState((previous) => ({
     variantName,
     palette: getDefaultPalette(previous.theme),
     parallax,
     hovered,
     opacity,
   }));
+
+  return true;
 };
 
 export function useThreeSceneSetup(
@@ -40,7 +48,27 @@ export function useThreeSceneSetup(
   }: SceneOptions = {},
 ) {
   useEffect(() => {
-    applySceneState(variantName, { opacity, parallax, hovered });
+    let animationFrame: number | undefined;
+
+    const apply = () => {
+      const applied = applySceneState(variantName, {
+        opacity,
+        parallax,
+        hovered,
+      });
+
+      if (!applied) {
+        animationFrame = window.requestAnimationFrame(apply);
+      }
+    };
+
+    apply();
+
+    return () => {
+      if (animationFrame !== undefined) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
   }, [hovered, opacity, parallax, variantName]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure three scene state updates wait for the canvas handle to be ready
- preserve existing reset behaviour while keeping opacity/parallax updates consistent

## Testing
- not run (Next.js ESLint setup prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e68b938270832f89a297eb5f430c5f