### PR TITLE
fix: restore route-specific 3D variant when closing menu

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -32,6 +32,7 @@ import {
   EXIT_NAVIGATION_ATTRIBUTE,
   navigateWithExit,
 } from "@/app/helpers/navigateWithExit";
+import { applyNavigationSceneVariant } from "@/app/helpers/threeNavigation";
 import { workProjects } from "@/app/work/projects";
 import { shouldAllowPrefetch } from "@/app/helpers/prefetch";
 import { useThreeApp } from "@/app/helpers/threeAppContext";
@@ -273,6 +274,10 @@ export default function Menu({
       setHoveredItem(null);
       baseVariantRef.current = null;
       baseOpacityRef.current = null;
+
+      if (typeof window !== "undefined") {
+        applyNavigationSceneVariant(pathname);
+      }
       return;
     }
 
@@ -283,7 +288,7 @@ export default function Menu({
     const snapshot = app.bundle.getState();
     baseVariantRef.current = createVariantState(snapshot.variant);
     baseOpacityRef.current = { ...snapshot.shapeOpacity };
-  }, [app, isOpen]);
+  }, [app, isOpen, pathname]);
 
   useEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
### Motivation
- Fix a bug where 3D shapes kept opacities/transformations from the menu (or a previously visited route like `/work`) after the menu closed instead of restoring the current route's variant.

### Description
- Import and call `applyNavigationSceneVariant(pathname)` on menu close to reapply the page's canonical 3D variant and shape opacities.

### Testing
- `npm run type-check` completed successfully.
- `npm run lint` failed due to an environment/project configuration error (`Invalid project directory provided, no such directory: /workspace/Duartois/lint`).
- An automated Playwright script navigated `/` → `/work` → `/` and produced a screenshot artifact showing the home view after return (script ran successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2096e9748326811ef619babc6992)